### PR TITLE
ExtField incorrect example

### DIFF
--- a/doc/Sphinx/namelist.rst
+++ b/doc/Sphinx/namelist.rst
@@ -709,7 +709,7 @@ External fields
 An external field can be applied using an ``ExtField`` block::
 
   ExtField(
-      fields = ["Ex"],
+      field = "Ex",
       profile = constant(0.01, xvacuum=0.1)
   )
 


### PR DESCRIPTION
ExtField has `field` instead of `fields` and also doesn't allow lists in it.