### PR TITLE
add new temporal profile tsin2plateau

### DIFF
--- a/src/Profiles/Function.cpp
+++ b/src/Profiles/Function.cpp
@@ -272,12 +272,12 @@ double Function_TimePolynomial::valueAt(double time) {
 double Function_TimeSin2Plateau::valueAt(double time) {
   if (time<start) {
     return 0.;
-  } else if ((time < start+fwhm)&&(fwhm!=0.)) {
-    return pow( sin(0.5*M_PI*(time-start)/fwhm) , 2 );
-  } else if (time < start+fwhm+plateau) {
+  } else if ((time < start+slope1)&&(slope1!=0.)) {
+    return pow( sin(0.5*M_PI*(time-start)/slope1) , 2 );
+  } else if (time < start+slope1+plateau) {
     return 1.;
-  } else if ((time < start+fwhm+plateau+fwhm2)&&(fwhm2!=0.)) {
-    return pow(  cos(0.5*M_PI*(time-start-fwhm-plateau)/fwhm2) , 2 );
+  } else if ((time < start+slope1+plateau+slope2)&&(slope2!=0.)) {
+    return pow(  cos(0.5*M_PI*(time-start-slope1-plateau)/slope2) , 2 );
   } else {
     return 0.;
   }

--- a/src/Profiles/Function.cpp
+++ b/src/Profiles/Function.cpp
@@ -272,12 +272,12 @@ double Function_TimePolynomial::valueAt(double time) {
 double Function_TimeFlatTopSin2::valueAt(double time) {
   if (time<start) {
     return 0.;
-  } else if ((time < start+fwhm1)&&(fwhm1!=0.)) {
-    return pow( sin(0.5*M_PI*(time-start)/fwhm1) , 2 );
-  } else if (time < start+fwhm1+plateau) {
+  } else if ((time < start+fwhm)&&(fwhm!=0.)) {
+    return pow( sin(0.5*M_PI*(time-start)/fwhm) , 2 );
+  } else if (time < start+fwhm+plateau) {
     return 1.;
-  } else if ((time < start+fwhm1+plateau+fwhm2)&&(fwhm2!=0.)) {
-    return pow(  cos(0.5*M_PI*(time-start-fwhm1-plateau)/fwhm2) , 2 );
+  } else if ((time < start+fwhm+plateau+fwhm2)&&(fwhm2!=0.)) {
+    return pow(  cos(0.5*M_PI*(time-start-fwhm-plateau)/fwhm2) , 2 );
   } else {
     return 0.;
   }

--- a/src/Profiles/Function.cpp
+++ b/src/Profiles/Function.cpp
@@ -268,3 +268,17 @@ double Function_TimePolynomial::valueAt(double time) {
     }
     return r;
 }
+// Time sin2 profile with a plateau the funtion and the derivative are continuos
+double Function_TimeFlatTopSin2::valueAt(double time) {
+  if (time<start) {
+    return 0.;
+  } else if ((time < start+fwhm1)&&(fwhm1!=0.)) {
+    return pow( sin(0.5*M_PI*(time-start)/fwhm1) , 2 );
+  } else if (time < start+fwhm1+plateau) {
+    return 1.;
+  } else if ((time < start+fwhm1+plateau+fwhm2)&&(fwhm2!=0.)) {
+    return pow(  cos(0.5*M_PI*(time-start-fwhm1-plateau)/fwhm2) , 2 );
+  } else {
+    return 0.;
+  }
+}

--- a/src/Profiles/Function.cpp
+++ b/src/Profiles/Function.cpp
@@ -269,7 +269,7 @@ double Function_TimePolynomial::valueAt(double time) {
     return r;
 }
 // Time sin2 profile with a plateau the funtion and the derivative are continuos
-double Function_TimeFlatTopSin2::valueAt(double time) {
+double Function_TimeSin2Plateau::valueAt(double time) {
   if (time<start) {
     return 0.;
   } else if ((time < start+fwhm)&&(fwhm!=0.)) {

--- a/src/Profiles/Function.h
+++ b/src/Profiles/Function.h
@@ -811,15 +811,15 @@ private:
 
 class Function_TimeFlatTopSin2 : public Function{
     public:
-    Function_TimeSin2 ( PyObject *py_profile ){
-      double duration;
+    Function_TimeFlatTopSin2 ( PyObject *py_profile ){
+      //double duration;
       PyTools::getAttr(py_profile, "start", start      );
       PyTools::getAttr(py_profile, "fwhm1", fwhm1 );
       PyTools::getAttr(py_profile, "plateau", plateau );
       PyTools::getAttr(py_profile, "fwhm2" , fwhm2 );
       end = start + fwhm1 + plateau + fwhm2;
     };
-    Function_TimeSin2 ( Function_TimeSin2 *f ){
+    Function_TimeFlatTopSin2 ( Function_TimeFlatTopSin2 *f ){
       start   = f->start;
       fwhm1   = f->fwhm1;
       plateau = f->plateau;

--- a/src/Profiles/Function.h
+++ b/src/Profiles/Function.h
@@ -809,4 +809,26 @@ private:
     std::vector<double> coeffs;
 };
 
+class Function_TimeFlatTopSin2 : public Function{
+    public:
+    Function_TimeSin2 ( PyObject *py_profile ){
+      double duration;
+      PyTools::getAttr(py_profile, "start", start      );
+      PyTools::getAttr(py_profile, "fwhm1", fwhm1 );
+      PyTools::getAttr(py_profile, "plateau", plateau );
+      PyTools::getAttr(py_profile, "fwhm2" , fwhm2 );
+      end = start + fwhm1 + plateau + fwhm2;
+    };
+    Function_TimeSin2 ( Function_TimeSin2 *f ){
+      start   = f->start;
+      fwhm1   = f->fwhm1;
+      plateau = f->plateau;
+      fwhm2   = f->fwhm2;
+      end     = f->end;
+    };
+    double valueAt(double);
+  private:
+    double start, fwhm1, plateau, fwhm2, end;
+};
+
 #endif

--- a/src/Profiles/Function.h
+++ b/src/Profiles/Function.h
@@ -814,21 +814,21 @@ class Function_TimeFlatTopSin2 : public Function{
     Function_TimeFlatTopSin2 ( PyObject *py_profile ){
       //double duration;
       PyTools::getAttr(py_profile, "start", start      );
-      PyTools::getAttr(py_profile, "fwhm1", fwhm1 );
+      PyTools::getAttr(py_profile, "fwhm", fwhm );
       PyTools::getAttr(py_profile, "plateau", plateau );
       PyTools::getAttr(py_profile, "fwhm2" , fwhm2 );
-      end = start + fwhm1 + plateau + fwhm2;
+      end = start + fwhm + plateau + fwhm2;
     };
     Function_TimeFlatTopSin2 ( Function_TimeFlatTopSin2 *f ){
       start   = f->start;
-      fwhm1   = f->fwhm1;
+      fwhm    = f->fwhm;
       plateau = f->plateau;
       fwhm2   = f->fwhm2;
       end     = f->end;
     };
     double valueAt(double);
   private:
-    double start, fwhm1, plateau, fwhm2, end;
+    double start, fwhm, plateau, fwhm2, end;
 };
 
 #endif

--- a/src/Profiles/Function.h
+++ b/src/Profiles/Function.h
@@ -809,9 +809,9 @@ private:
     std::vector<double> coeffs;
 };
 
-class Function_TimeFlatTopSin2 : public Function{
+class Function_TimeSin2Plateau : public Function{
     public:
-    Function_TimeFlatTopSin2 ( PyObject *py_profile ){
+    Function_TimeSin2Plateau ( PyObject *py_profile ){
       //double duration;
       PyTools::getAttr(py_profile, "start", start      );
       PyTools::getAttr(py_profile, "fwhm", fwhm );
@@ -819,7 +819,7 @@ class Function_TimeFlatTopSin2 : public Function{
       PyTools::getAttr(py_profile, "fwhm2" , fwhm2 );
       end = start + fwhm + plateau + fwhm2;
     };
-    Function_TimeFlatTopSin2 ( Function_TimeFlatTopSin2 *f ){
+    Function_TimeSin2Plateau ( Function_TimeSin2Plateau *f ){
       start   = f->start;
       fwhm    = f->fwhm;
       plateau = f->plateau;

--- a/src/Profiles/Function.h
+++ b/src/Profiles/Function.h
@@ -814,21 +814,21 @@ class Function_TimeSin2Plateau : public Function{
     Function_TimeSin2Plateau ( PyObject *py_profile ){
       //double duration;
       PyTools::getAttr(py_profile, "start", start      );
-      PyTools::getAttr(py_profile, "fwhm", fwhm );
+      PyTools::getAttr(py_profile, "slope1", slope1 );
       PyTools::getAttr(py_profile, "plateau", plateau );
-      PyTools::getAttr(py_profile, "fwhm2" , fwhm2 );
-      end = start + fwhm + plateau + fwhm2;
+      PyTools::getAttr(py_profile, "slope2" , slope2 );
+      end = start + slope1 + plateau + slope2;
     };
     Function_TimeSin2Plateau ( Function_TimeSin2Plateau *f ){
       start   = f->start;
-      fwhm    = f->fwhm;
+      slope1    = f->slope1;
       plateau = f->plateau;
-      fwhm2   = f->fwhm2;
+      slope2   = f->slope2;
       end     = f->end;
     };
     double valueAt(double);
   private:
-    double start, fwhm, plateau, fwhm2, end;
+    double start, slope1, plateau, slope2, end;
 };
 
 #endif

--- a/src/Profiles/Profile.cpp
+++ b/src/Profiles/Profile.cpp
@@ -298,7 +298,7 @@ Profile::Profile(Profile *p){
       function = new Function_TimeCosine(static_cast<Function_TimeCosine*>(p->function));
     } else if( profileName == "tpolynomial" ){
       function = new Function_TimePolynomial(static_cast<Function_TimePolynomial*>(p->function));
-    }else if( profileName == "tflattopsin2" ){
+    } else if( profileName == "tflattopsin2" ){
       function = new Function_TimeFlatTopSin2(static_cast<Function_TimeFlatTopSin2*>(p->function));
     }
   }else {

--- a/src/Profiles/Profile.cpp
+++ b/src/Profiles/Profile.cpp
@@ -137,12 +137,12 @@ Profile::Profile(PyObject* py_profile, unsigned int nvariables, string name, boo
             else
                 ERROR("Profile `"<<name<<"`: tpolynomial() profile is only for time");
             
-        } else if( profileName == "tflattopsin2" ){
+        } else if( profileName == "tsin2plateau" ){
 
           if( nvariables == 1 )
-            function = new Function_TimeFlatTopSin2(py_profile);
+            function = new Function_TimeSin2Plateau(py_profile);
           else
-            ERROR("Profile `"<<name<<"`: tflattopsin2() profile is only for time");
+            ERROR("Profile `"<<name<<"`: tsin2plateau() profile is only for time");
         }
 
     }
@@ -298,8 +298,8 @@ Profile::Profile(Profile *p){
       function = new Function_TimeCosine(static_cast<Function_TimeCosine*>(p->function));
     } else if( profileName == "tpolynomial" ){
       function = new Function_TimePolynomial(static_cast<Function_TimePolynomial*>(p->function));
-    } else if( profileName == "tflattopsin2" ){
-      function = new Function_TimeFlatTopSin2(static_cast<Function_TimeFlatTopSin2*>(p->function));
+    } else if( profileName == "tsin2plateau" ){
+      function = new Function_TimeSin2Plateau(static_cast<Function_TimeSin2Plateau*>(p->function));
     }
   }else {
     if      ( nvariables == 1 ) function = new Function_Python1D(static_cast<Function_Python1D*>(p->function));

--- a/src/Profiles/Profile.cpp
+++ b/src/Profiles/Profile.cpp
@@ -137,8 +137,14 @@ Profile::Profile(PyObject* py_profile, unsigned int nvariables, string name, boo
             else
                 ERROR("Profile `"<<name<<"`: tpolynomial() profile is only for time");
             
+        } else if( profileName == "tflattopsin2" ){
+
+          if( nvariables == 1 )
+            function = new Function_TimeFlatTopSin2(py_profile);
+          else
+            ERROR("Profile `"<<name<<"`: tflattopsin2() profile is only for time");
         }
-        
+
     }
     
     // Otherwise (if the python profile cannot be hard-coded) ....
@@ -232,79 +238,81 @@ Profile::Profile(PyObject* py_profile, unsigned int nvariables, string name, boo
 
 
 // Cloning constructor
-Profile::Profile(Profile *p)
-{
-    profileName = p->profileName;
-    nvariables  = p->nvariables ;
-    info        = p->info       ;
-    uses_numpy  = p->uses_numpy ;
-    if( profileName != "" ) {
-        if( profileName == "constant" ) {
-            if     ( nvariables == 1 )
-                function = new Function_Constant1D(static_cast<Function_Constant1D*>(p->function));
-            else if( nvariables == 2 )
-                function = new Function_Constant2D(static_cast<Function_Constant2D*>(p->function));
-            else if( nvariables == 3 )
-                function = new Function_Constant3D(static_cast<Function_Constant3D*>(p->function));
-        } else if( profileName == "trapezoidal" ){
-            if     ( nvariables == 1 )
-                function = new Function_Trapezoidal1D(static_cast<Function_Trapezoidal1D*>(p->function));
-            else if( nvariables == 2 )
-                function = new Function_Trapezoidal2D(static_cast<Function_Trapezoidal2D*>(p->function));
-            else if( nvariables == 3 )
-                function = new Function_Trapezoidal3D(static_cast<Function_Trapezoidal3D*>(p->function));
-        } else if( profileName == "gaussian" ){
-            if     ( nvariables == 1 )
-                function = new Function_Gaussian1D(static_cast<Function_Gaussian1D*>(p->function));
-            else if( nvariables == 2 )
-                function = new Function_Gaussian2D(static_cast<Function_Gaussian2D*>(p->function));
-            else if( nvariables == 3 )
-                function = new Function_Gaussian3D(static_cast<Function_Gaussian3D*>(p->function));
-        } else if( profileName == "polygonal" ){
-            if     ( nvariables == 1 )
-                function = new Function_Polygonal1D(static_cast<Function_Polygonal1D*>(p->function));
-            else if( nvariables == 2 )
-                function = new Function_Polygonal2D(static_cast<Function_Polygonal2D*>(p->function));
-            else if( nvariables == 3 )
-                function = new Function_Polygonal3D(static_cast<Function_Polygonal3D*>(p->function));
-        } else if( profileName == "cosine" ){
-            if     ( nvariables == 1 )
-                function = new Function_Cosine1D(static_cast<Function_Cosine1D*>(p->function));
-            else if( nvariables == 2 )
-                function = new Function_Cosine2D(static_cast<Function_Cosine2D*>(p->function));
-            else if( nvariables == 3 )
-                function = new Function_Cosine3D(static_cast<Function_Cosine3D*>(p->function));
-        } else if( profileName == "polynomial" ){
-            if     ( nvariables == 1 )
-                function = new Function_Polynomial1D(static_cast<Function_Polynomial1D*>(p->function));
-            else if( nvariables == 2 )
-                function = new Function_Polynomial2D(static_cast<Function_Polynomial2D*>(p->function));
-            else if( nvariables == 3 )
-                function = new Function_Polynomial3D(static_cast<Function_Polynomial3D*>(p->function));
-        } else if( profileName == "tconstant" ){
-            function = new Function_TimeConstant(static_cast<Function_TimeConstant*>(p->function));
-        } else if( profileName == "ttrapezoidal" ){
-            function = new Function_TimeTrapezoidal(static_cast<Function_TimeTrapezoidal*>(p->function));
-        } else if( profileName == "tgaussian" ){
-            function = new Function_TimeGaussian(static_cast<Function_TimeGaussian*>(p->function));
-        } else if( profileName == "tpolygonal" ){
-            function = new Function_TimePolygonal(static_cast<Function_TimePolygonal*>(p->function));
-        } else if( profileName == "tcosine" ){
-            function = new Function_TimeCosine(static_cast<Function_TimeCosine*>(p->function));
-        } else if( profileName == "tpolynomial" ){
-            function = new Function_TimePolynomial(static_cast<Function_TimePolynomial*>(p->function));
-        }
-    } else {
-        if      ( nvariables == 1 ) function = new Function_Python1D(static_cast<Function_Python1D*>(p->function));
-        else if ( nvariables == 2 ) function = new Function_Python2D(static_cast<Function_Python2D*>(p->function));
-        else if ( nvariables == 3 ) function = new Function_Python3D(static_cast<Function_Python3D*>(p->function));
+Profile::Profile(Profile *p){
+  profileName = p->profileName;
+  nvariables  = p->nvariables ;
+  info        = p->info       ;
+  uses_numpy  = p->uses_numpy ;
+  if( profileName != "" ) {
+    if( profileName == "constant" ) {
+      if     ( nvariables == 1 )
+        function = new Function_Constant1D(static_cast<Function_Constant1D*>(p->function));
+      else if( nvariables == 2 )
+        function = new Function_Constant2D(static_cast<Function_Constant2D*>(p->function));
+      else if( nvariables == 3 )
+        function = new Function_Constant3D(static_cast<Function_Constant3D*>(p->function));
+    } else if( profileName == "trapezoidal" ){
+      if     ( nvariables == 1 )
+        function = new Function_Trapezoidal1D(static_cast<Function_Trapezoidal1D*>(p->function));
+      else if( nvariables == 2 )
+        function = new Function_Trapezoidal2D(static_cast<Function_Trapezoidal2D*>(p->function));
+      else if( nvariables == 3 )
+        function = new Function_Trapezoidal3D(static_cast<Function_Trapezoidal3D*>(p->function));
+    } else if( profileName == "gaussian" ){
+      if     ( nvariables == 1 )
+        function = new Function_Gaussian1D(static_cast<Function_Gaussian1D*>(p->function));
+      else if( nvariables == 2 )
+        function = new Function_Gaussian2D(static_cast<Function_Gaussian2D*>(p->function));
+      else if( nvariables == 3 )
+        function = new Function_Gaussian3D(static_cast<Function_Gaussian3D*>(p->function));
+    } else if( profileName == "polygonal" ){
+      if     ( nvariables == 1 )
+        function = new Function_Polygonal1D(static_cast<Function_Polygonal1D*>(p->function));
+      else if( nvariables == 2 )
+        function = new Function_Polygonal2D(static_cast<Function_Polygonal2D*>(p->function));
+      else if( nvariables == 3 )
+        function = new Function_Polygonal3D(static_cast<Function_Polygonal3D*>(p->function));
+    } else if( profileName == "cosine" ){
+      if     ( nvariables == 1 )
+        function = new Function_Cosine1D(static_cast<Function_Cosine1D*>(p->function));
+      else if( nvariables == 2 )
+        function = new Function_Cosine2D(static_cast<Function_Cosine2D*>(p->function));
+      else if( nvariables == 3 )
+        function = new Function_Cosine3D(static_cast<Function_Cosine3D*>(p->function));
+    } else if( profileName == "polynomial" ){
+      if     ( nvariables == 1 )
+        function = new Function_Polynomial1D(static_cast<Function_Polynomial1D*>(p->function));
+      else if( nvariables == 2 )
+        function = new Function_Polynomial2D(static_cast<Function_Polynomial2D*>(p->function));
+      else if( nvariables == 3 )
+        function = new Function_Polynomial3D(static_cast<Function_Polynomial3D*>(p->function));
+    } else if( profileName == "tconstant" ){
+      function = new Function_TimeConstant(static_cast<Function_TimeConstant*>(p->function));
+    } else if( profileName == "ttrapezoidal" ){
+      function = new Function_TimeTrapezoidal(static_cast<Function_TimeTrapezoidal*>(p->function));
+    } else if( profileName == "tgaussian" ){
+      function = new Function_TimeGaussian(static_cast<Function_TimeGaussian*>(p->function));
+    } else if( profileName == "tpolygonal" ){
+      function = new Function_TimePolygonal(static_cast<Function_TimePolygonal*>(p->function));
+    } else if( profileName == "tcosine" ){
+      function = new Function_TimeCosine(static_cast<Function_TimeCosine*>(p->function));
+    } else if( profileName == "tpolynomial" ){
+      function = new Function_TimePolynomial(static_cast<Function_TimePolynomial*>(p->function));
+    }else if( profileName == "tflattopsin2" ){
+      function = new Function_TimeFlatTopSin2(static_cast<Function_TimeFlatTopSin2*>(p->function));
     }
+  }else {
+    if      ( nvariables == 1 ) function = new Function_Python1D(static_cast<Function_Python1D*>(p->function));
+    else if ( nvariables == 2 ) function = new Function_Python2D(static_cast<Function_Python2D*>(p->function));
+    else if ( nvariables == 3 ) function = new Function_Python3D(static_cast<Function_Python3D*>(p->function));
+  }
 }
+
 
 
 Profile::~Profile()
 {
-    delete function;
+  delete function;
 }
 
 

--- a/src/Python/pyprofiles.py
+++ b/src/Python/pyprofiles.py
@@ -446,12 +446,12 @@ def tflattopsin2(start=0., fwhm1=0., plateau=None, fwhm2=None):
             return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm1-plateau)/fwhm2) , 2 )
         else:
             return 0.
-        f.profileName = "tflattopsin2"
-        f.start       = start
-        f.fwhm1       = fwhm1
-        f.plateau     = plateau
-        f.fwhm2       = fwhm2
-        return f
+    f.profileName = "tflattopsin2"
+    f.start       = start
+    f.fwhm1       = fwhm1
+    f.plateau     = plateau
+    f.fwhm2       = fwhm2
+    return f
 
 
 def transformPolarization(polarizationPhi, ellipticity):

--- a/src/Python/pyprofiles.py
+++ b/src/Python/pyprofiles.py
@@ -428,6 +428,31 @@ def tpolynomial(**kwargs):
         f.coeffs.append( c     )
     return f
 
+def tflattopsin2(start=0., fwhm1=0., plateau=None, fwhm2=None):
+    import math
+    global Main
+    if len(Main)==0:
+        raise Exception("tflattopsin2 profile has been defined before `Main()`")
+    if plateau is None: plateau = 0 # default is a simple sin2 profile (could be used for a 2D or 3D laserPulse too)
+    if fwhm2 is None: fwhm2 = fwhm1
+    def f(t):
+        if t < start:
+            return 0.
+        elif (t < start+fwhm1) and (fwhm1!=0.):
+            return math.pow( math.sin(0.5*math.pi*(t-start)/fwhm1) , 2 )
+        elif t < start+fwhm1+plateau:
+            return 1.
+        elif t < start+fwhm1+plateau+fwhm2 and (fwhm2!=0.):
+            return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm1-plateau)/fwhm2) , 2 )
+        else:
+            return 0.
+        f.profileName = "tsin2"
+        f.start       = start
+        f.fwhm1       = fwhm1
+        f.plateau     = plateau
+        f.fwhm2       = fwhm2
+        return f
+
 
 def transformPolarization(polarizationPhi, ellipticity):
     import math
@@ -554,30 +579,6 @@ def LaserGaussian3D( boxSide="xmin", a0=1., omega=1., focus=None, waist=3., inci
         phase          = [ lambda y,z:phase(y,z)-phaseZero+dephasing, lambda y,z:phase(y,z)-phaseZero ],
     )
 
-def tflattopsin2(start=0., fwhm1=0., plateau=None, fwhm2=None):
-    import math
-    global Main
-    if len(Main)==0:
-        raise Exception("tflattopsin2 profile has been defined before `Main()`")
-    if plateau is None: plateau = 0 # default is a simple sin2 profile (could be used for a 2D or 3D laserPulse too)
-    if fwhm2 is None: fwhm2 = fwhm1
-    def f(t):
-        if t < start:
-            return 0.
-        elif (t < start+fwhm1) and (fwhm1!=0.):
-            return math.pow( math.sin(0.5*math.pi*(t-start)/fwhm1) , 2 )
-        elif t < start+fwhm1+plateau:
-            return 1.
-        elif t < start+fwhm1+plateau+fwhm2 and (fwhm2!=0.):
-            return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm1-plateau)/fwhm2) , 2 )
-        else:
-            return 0.
-        f.profileName = "tsin2"
-        f.start       = start
-        f.fwhm1       = fwhm1
-        f.plateau     = plateau
-        f.fwhm2       = fwhm2
-        return f
 
 """
 -----------------------------------------------------------------------

--- a/src/Python/pyprofiles.py
+++ b/src/Python/pyprofiles.py
@@ -554,6 +554,31 @@ def LaserGaussian3D( boxSide="xmin", a0=1., omega=1., focus=None, waist=3., inci
         phase          = [ lambda y,z:phase(y,z)-phaseZero+dephasing, lambda y,z:phase(y,z)-phaseZero ],
     )
 
+def tflattopsin2(start=0., fwhm1=0., plateau=None, fwhm2=None):
+    import math
+    global Main
+    if len(Main)==0:
+        raise Exception("tflattopsin2 profile has been defined before `Main()`")
+    if plateau is None: plateau = 0 # default is a simple sin2 profile (could be used for a 2D or 3D laserPulse too)
+    if fwhm2 is None: fwhm2 = fwhm1
+    def f(t):
+        if t < start:
+            return 0.
+        elif (t < start+fwhm1) and (fwhm1!=0.):
+            return math.pow( math.sin(0.5*math.pi*(t-start)/fwhm1) , 2 )
+        elif t < start+fwhm1+plateau:
+            return 1.
+        elif t < start+fwhm1+plateau+fwhm2 and (fwhm2!=0.):
+            return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm1-plateau)/fwhm2) , 2 )
+        else:
+            return 0.
+        f.profileName = "tsin2"
+        f.start       = start
+        f.fwhm1       = fwhm1
+        f.plateau     = plateau
+        f.fwhm2       = fwhm2
+        return f
+
 """
 -----------------------------------------------------------------------
     BEGINNING OF THE USER NAMELIST

--- a/src/Python/pyprofiles.py
+++ b/src/Python/pyprofiles.py
@@ -428,13 +428,14 @@ def tpolynomial(**kwargs):
         f.coeffs.append( c     )
     return f
 
-def tsin2plateau(start=0., fwhm=0., plateau=None, fwhm2=None):
+def tsin2plateau(start=0., fwhm=0., plateau=None, slope1=None, slope2=None):
     import math
     global Main
     if len(Main)==0:
         raise Exception("tsin2plateau profile has been defined before `Main()`")
     if plateau is None: plateau = 0 # default is a simple sin2 profile (could be used for a 2D or 3D laserPulse too)
-    if fwhm2 is None: fwhm2 = fwhm
+    if slope1 is None: slope1 = fwhm
+    if slope2 is None: slope2 = slope1
     def f(t):
         if t < start:
             return 0.
@@ -442,15 +443,16 @@ def tsin2plateau(start=0., fwhm=0., plateau=None, fwhm2=None):
             return math.pow( math.sin(0.5*math.pi*(t-start)/fwhm) , 2 )
         elif t < start+fwhm+plateau:
             return 1.
-        elif t < start+fwhm+plateau+fwhm2 and (fwhm2!=0.):
-            return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm-plateau)/fwhm2) , 2 )
+        elif t < start+fwhm+plateau+slope2 and (slope2!=0.):
+            return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm-plateau)/slope2) , 2 )
         else:
             return 0.
     f.profileName = "tsin2plateau"
     f.start       = start
-    f.fwhm        = fwhm
+    #f.fwhm        = fwhm
     f.plateau     = plateau
-    f.fwhm2       = fwhm2
+    f.slope1      = slope1
+    f.slope2      = slope2
     return f
 
 

--- a/src/Python/pyprofiles.py
+++ b/src/Python/pyprofiles.py
@@ -428,11 +428,11 @@ def tpolynomial(**kwargs):
         f.coeffs.append( c     )
     return f
 
-def tflattopsin2(start=0., fwhm=0., plateau=None, fwhm2=None):
+def tsin2plateau(start=0., fwhm=0., plateau=None, fwhm2=None):
     import math
     global Main
     if len(Main)==0:
-        raise Exception("tflattopsin2 profile has been defined before `Main()`")
+        raise Exception("tsin2plateau profile has been defined before `Main()`")
     if plateau is None: plateau = 0 # default is a simple sin2 profile (could be used for a 2D or 3D laserPulse too)
     if fwhm2 is None: fwhm2 = fwhm
     def f(t):
@@ -446,7 +446,7 @@ def tflattopsin2(start=0., fwhm=0., plateau=None, fwhm2=None):
             return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm-plateau)/fwhm2) , 2 )
         else:
             return 0.
-    f.profileName = "tflattopsin2"
+    f.profileName = "tsin2plateau"
     f.start       = start
     f.fwhm        = fwhm
     f.plateau     = plateau

--- a/src/Python/pyprofiles.py
+++ b/src/Python/pyprofiles.py
@@ -446,7 +446,7 @@ def tflattopsin2(start=0., fwhm1=0., plateau=None, fwhm2=None):
             return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm1-plateau)/fwhm2) , 2 )
         else:
             return 0.
-        f.profileName = "tsin2"
+        f.profileName = "tflattopsin2"
         f.start       = start
         f.fwhm1       = fwhm1
         f.plateau     = plateau

--- a/src/Python/pyprofiles.py
+++ b/src/Python/pyprofiles.py
@@ -428,27 +428,27 @@ def tpolynomial(**kwargs):
         f.coeffs.append( c     )
     return f
 
-def tflattopsin2(start=0., fwhm1=0., plateau=None, fwhm2=None):
+def tflattopsin2(start=0., fwhm=0., plateau=None, fwhm2=None):
     import math
     global Main
     if len(Main)==0:
         raise Exception("tflattopsin2 profile has been defined before `Main()`")
     if plateau is None: plateau = 0 # default is a simple sin2 profile (could be used for a 2D or 3D laserPulse too)
-    if fwhm2 is None: fwhm2 = fwhm1
+    if fwhm2 is None: fwhm2 = fwhm
     def f(t):
         if t < start:
             return 0.
-        elif (t < start+fwhm1) and (fwhm1!=0.):
-            return math.pow( math.sin(0.5*math.pi*(t-start)/fwhm1) , 2 )
-        elif t < start+fwhm1+plateau:
+        elif (t < start+fwhm) and (fwhm!=0.):
+            return math.pow( math.sin(0.5*math.pi*(t-start)/fwhm) , 2 )
+        elif t < start+fwhm+plateau:
             return 1.
-        elif t < start+fwhm1+plateau+fwhm2 and (fwhm2!=0.):
-            return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm1-plateau)/fwhm2) , 2 )
+        elif t < start+fwhm+plateau+fwhm2 and (fwhm2!=0.):
+            return math.pow(  math.cos(0.5*math.pi*(t-start-fwhm-plateau)/fwhm2) , 2 )
         else:
             return 0.
     f.profileName = "tflattopsin2"
     f.start       = start
-    f.fwhm1       = fwhm1
+    f.fwhm        = fwhm
     f.plateau     = plateau
     f.fwhm2       = fwhm2
     return f


### PR DESCRIPTION
I propose to add a temporal profile that is very useful for several simulations:
`tsin2plateau`, a sin2 profile with the option to become flattop profile with sin2 ramps.

I used the code that Micka and Anna developed some time ago and I refactored it.
I changed the default values: if only one parameters is given (`fwhm`) the profile is similar to a Gaussian profile having fwhm (of the field amplitude) defined by the user.
If `plateau` is also given, a plateau is added splitting in two the previous profile.
If the user defines `slope1` and/or `slope2`, he/she controls the width of the sin2 ramps at the beginning and at the end of the profile. 
See attachment.

Someone might not like the redundancy of `fwhm`, `slope1`, `slope2`.
`slope1`, `slope2` use `fwhm` as default value. If they both are defined,
`fwhm` is not used, it gets overridden, and the values of `slope1`, `slope2`are used.
I chose to let the user use 
`time_envelope   = tsin2plateau(fwhm=70.*t0)`
to have a simple way to define a laser envelope that can be useful also in 2D and 3D.
A sin2 profile has the advantage to have a compact support,
no truncation is needed to approach zero, and its derivative is continuous.

![sin2plateau](https://user-images.githubusercontent.com/1061569/26935839-4a0371c6-4c6d-11e7-8240-1e41a8a1cc4b.png)