### PR TITLE
Fix LaserGaussian2D amplitude problem

### DIFF
--- a/src/Python/pyprofiles.py
+++ b/src/Python/pyprofiles.py
@@ -523,7 +523,7 @@ def LaserGaussian2D( box_side="xmin", a0=1., omega=1., focus=None, waist=3., inc
         invWaist2 = (w/waist)**2
         coeff = -omega * focus[0] * w**2 / (2.*Zr**2)
         def spatial(y):
-            return w * exp( -invWaist2*(y-focus[1])**2 )
+            return sqrt(w) * exp( -invWaist2*(y-focus[1])**2 )
         def phase(y):
             return coeff * (y-focus[1])**2
     else:
@@ -537,7 +537,7 @@ def LaserGaussian2D( box_side="xmin", a0=1., omega=1., focus=None, waist=3., inc
         amplitudeZ *= cos(incidence_angle)
         def spatial(y):
             w2 = 1./(1. + invZr2*(y-Y1)**2)
-            return sqrt(w2) * exp( -invWaist2*w2*(y-Y2)**2 )
+            return sqrt(sqrt(w2)) * exp( -invWaist2*w2*(y-Y2)**2 )
         def phase(y):
             dy = y-Y1
             return omega_*dy*(1.+ invZr3*(y-Y2)**2/(1.+invZr2*dy**2)) + atan(invZr*dy)
@@ -568,7 +568,7 @@ def LaserEnvelopeGaussian2D( a0=1., omega=1., focus=None, waist=3., time_envelop
         return coeff
     def spatial_amplitude(x,y):
         invWaist2 = (w(x)/waist)**2
-        return w(x) * math.exp( -invWaist2*(  (y-focus[1])**2  ) )
+        return math.sqrt(w(x)) * math.exp( -invWaist2*(  (y-focus[1])**2  ) )
     def phase(x,y):
         return coeff(x) * ( (y-focus[1])**2 )
     def Gouy_phase(x):


### PR DESCRIPTION
It seems that the formula for a three-dimensional Gaussian beam's laser amplitude was used for the two-dimensional lasers as well. For a two-dimensional Gaussian beam the electric field amplitude falls as the square root of beam radius, as per [Eq. (2.30) here](http://www.phys.ncku.edu.tw/~cctsai/teaching/10202/gaussian%20beam%20derive.pdf).

I have conducted some tests to verify that the problem is real and that these changes fix it, using the following namelist:

```python
from numpy import pi

l0 = 2.*pi                      # laser wavelength
t0 = l0	                        # optical cycle
Lsim = [800*l0,300.*l0]         # length of the simulation
Tsim = 1500.*t0			# duration of the simulation
resx = 16.                       # nb of cells in on laser wavelength
rest = 48.                       # nb of timestep in one optical cycle 

x_f = 0 * l0
# x_f = 400 * l0

Main(
	geometry = "2Dcartesian",
	
	interpolation_order = 2 ,
	
	cell_length = [l0/resx,l0/resx],
	grid_length  = Lsim,
	
	number_of_patches = [ 16, 16 ],
	
	timestep = t0/rest,
	simulation_time = Tsim,
	 
	EM_boundary_conditions = [
		['silver-muller'],
		['periodic'],
	],

	EM_boundary_conditions_k = [
		[1., 0.], [-1., 0.],
		[0., 1.], [0., -1.]
	],
	
	random_seed = smilei_mpi_rank
)

LaserGaussian2D(
	waist           = 6.0/pi * l0,
	box_side        = "xmin",
	a0              = 10,
	focus           = [x_f, 150 * l0],
	time_envelope   = ttrapezoidal(plateau=200.*t0)
)

DiagScalar(
	every = 800,
)
```

Firstly the behaviour of `master` branch. The blue line corresponds to focal position at the wall the laser is being injected from (`x_f = 0* l0`) and the green line to focusing in the box centre (`x_f = 400 * l0`)
![broken](https://user-images.githubusercontent.com/543022/52409863-9e5c7600-2ace-11e9-8cbf-6a54d2818cce.png)
It is clear that identical lasers carry energy differing by orders of magnitude due only to a change in focal position.

Now, the behaviour with the current changes, under the same conditions:
![fixed](https://user-images.githubusercontent.com/543022/52410263-b8e31f00-2acf-11e9-87de-ff4a4fc41ed9.png)
The laser energy now does not depend on the focal position.