### PR TITLE
Marconi KNL compilation script now works

### DIFF
--- a/scripts/CompileTools/machine/marconi_knl_intel
+++ b/scripts/CompileTools/machine/marconi_knl_intel
@@ -8,15 +8,18 @@
 # module load mkl
 # module load szip # For hdf5
 # module load zlib/1.2.8--gnu--6.1.0 # For hdf5
-# module load hdf5
+# module load hdf5/1.8.18--intelmpi--2017--binary
+# LDFLAGS += -L/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/lib/intel64 -limf -lsvml -lirng -lintlc -liomp5
 #
-# Intel 2018:
+# Intel 2018 (preferred configuration):
+# module load profile/base
+# module load env-knl
 # module load intel/pe-xe-2018--binary
 # module load intelmpi/2018--binary
 # module load mkl/2018--binary
-# module load szip # For hdf5
+# module load szip/2.1--gnu--6.1.0  # For hdf5
 # module load zlib/1.2.8--gnu--6.1.0 # For hdf5
-# module load hdf5
+# module load hdf5/1.8.18--intelmpi--2018--binary
 #
 # Python:
 # Install `Anaconda 2` for Python because the default version does not work properly for Smilei.
@@ -28,5 +31,9 @@
 # Additional compilation flags:
 # - -fno-alias
 
-HDF5_ROOT_DIR=${HDF5_HOME}
+#HDF5_ROOT_DIR = ${HDF5_HOME}   #This one must be exported manually, a simple call to machine=marconi_knl_intel doesn't work
 CXXFLAGS += -cxx=icpc -xMIC-AVX512 -ip -inline-factor=1000 #-ipo
+LDFLAGS += -L/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/lib/intel64 -limf -lsvml -lirng -lintlc -liomp5
+#LDFLAGS += -limf -lsvml -lirng -lintlc -liomp5
+#
+# make -j64 machine=marconi_knl_intel


### PR DESCRIPTION
CINECA Marconi KNL intel compilation script is fixed (instrucions have been updated to intel-2018).