### PR TITLE
Marconi knl compilation script updated

### DIFF
--- a/scripts/CompileTools/machine/marconi_knl_intel
+++ b/scripts/CompileTools/machine/marconi_knl_intel
@@ -30,8 +30,8 @@
 # ```
 # Additional compilation flags:
 # - -fno-alias
-# Must manually export SMILEICXX=mpiicpc
-HDF5_ROOT_DIR += /cineca/prod/opt/libraries/hdf5/1.10.4/intelmpi--2018--binary/
+SMILEICXX=mpiicpc
+HDF5_ROOT_DIR = /cineca/prod/opt/libraries/hdf5/1.10.4/intelmpi--2018--binary/
 CXXFLAGS += -cxx=icpc -xMIC-AVX512 -ip -inline-factor=1000 #-ipo
 #
 # make -j64 machine=marconi_knl_intel


### PR DESCRIPTION
Now Smilei can be compiled on MARCONI (KNL) with just the `machine=marconi_knl_intel` option when calling make. No more manual exports are required.