### PR TITLE
Happi Quality-of-Life changes

### DIFF
--- a/doc/Sphinx/post-processing.rst
+++ b/doc/Sphinx/post-processing.rst
@@ -804,7 +804,7 @@ there are many more optional arguments. They are directly passed to the *matplot
 
 .. rubric:: For the colorbar: ``cbaspect``, ``orientation``, ``fraction``, ``pad``,
   ``shrink``, ``anchor``, ``panchor``, ``extend``, ``extendfrac``, ``extendrect``,
-  ``spacing``, ``ticks``, ``format``, ``drawedges``, ``size``
+  ``spacing``, ``ticks``, ``format``, ``drawedges``, ``size``, ``clabel``
 
 ..
 

--- a/doc/Sphinx/post-processing.rst
+++ b/doc/Sphinx/post-processing.rst
@@ -444,8 +444,10 @@ to manipulate the plotting options:
 
 * ``figure``: The figure number that is passed to matplotlib.
 * ``vmin``, ``vmax``: data value limits.
-* ``vsym``: indicates that data is symmetric about zero. In the absence
-  of ``vmin`` and ``vmax``, sets them to ``[-1, 1]*max(abs(data))`` respectively.
+* ``vsym``: indicates that data is symmetric about zero. If set to a number,
+  data limits are set to ``[-vsym, vsym]``. If set to ``True``, limits autoscale
+  to the values present in the simulation, but remain symmetric. If ``vmin`` or
+  ``vmax`` are set, they are ignored.
   Sets default colormap to ``smileiD``.
 * ``xmin``, ``xmax``, ``ymin``, ``ymax``: axes limits.
 * ``xfactor``, ``yfactor``: factors to rescale axes.

--- a/doc/Sphinx/post-processing.rst
+++ b/doc/Sphinx/post-processing.rst
@@ -87,7 +87,7 @@ In the case of the species, you can also obtain a given species by its name::
 Open a Scalar diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:method:: Scalar(scalar=None, timesteps=None, units=[""], data_log=False, **kwargs)
+.. py:method:: Scalar(scalar=None, timesteps=None, units=[""], data_log=False, data_transform=None, **kwargs)
 
   * ``scalar``: The name of the scalar.
      | If not given, then a list of available scalars is printed.
@@ -98,6 +98,8 @@ Open a Scalar diagnostic
   * ``units``: A unit specification (see :ref:`units`)
   * ``data_log``:
      | If ``True``, then :math:`\log_{10}` is applied to the output.
+  * ``data_transform``:
+     | If ``callable``, is applied to the output.
   * See also :ref:`otherkwargs`
 
 **Example**::
@@ -110,9 +112,9 @@ Open a Scalar diagnostic
 Open a Field diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:method:: Field(diagNumber=None, field=None, timesteps=None, subset=None, average=None, units=[""], data_log=False, moving=False, export_dir=None, **kwargs)
+.. py:method:: Field(diagNumber=None, field=None, timesteps=None, subset=None, average=None, units=[""], data_log=False, data_transform=None, moving=False, export_dir=None, **kwargs)
 
-  * ``timesteps``, ``units``, ``data_log``: same as before.
+  * ``timesteps``, ``units``, ``data_log``, ``data_transform``: same as before.
   * ``diagNumber``: number or ``name`` of the fields diagnostic
      | If not given, then a list of available diagnostic numbers is printed.
   * ``field``: The name of a field (``"Ex"``, ``"Ey"``, etc.)
@@ -168,9 +170,9 @@ Open a Field diagnostic
 Open a Probe diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:method:: Probe(probeNumber=None, field=None, timesteps=None, subset=None, average=None, units=[""], data_log=False, **kwargs)
+.. py:method:: Probe(probeNumber=None, field=None, timesteps=None, subset=None, average=None, units=[""], data_log=False, data_transform=None, **kwargs)
 
-  * ``timesteps``, ``units``, ``data_log``, ``export_dir``: same as before.
+  * ``timesteps``, ``units``, ``data_log``, ``data_transform``, ``export_dir``: same as before.
   * ``probeNumber``: number or ``name`` of the probe (the first one has number 0).
      | If not given, a list of available probes is printed.
   * ``field``: name of the field (``"Bx"``, ``"By"``, ``"Bz"``, ``"Ex"``, ``"Ey"``, ``"Ez"``, ``"Jx"``, ``"Jy"``, ``"Jz"`` or ``"Rho"``).
@@ -191,9 +193,9 @@ Open a Probe diagnostic
 Open a ParticleBinning diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:method:: ParticleBinning(diagNumber=None, timesteps=None, subset=None, sum=None, units=[""], data_log=False, **kwargs)
+.. py:method:: ParticleBinning(diagNumber=None, timesteps=None, subset=None, sum=None, units=[""], data_log=False, data_transform=None, **kwargs)
 
-  * ``timesteps``, ``units``, ``data_log``, ``export_dir``: same as before.
+  * ``timesteps``, ``units``, ``data_log``, ``data_transform``, ``export_dir``: same as before.
   * ``diagNumber``: number or ``name`` of the particle binning diagnostic (starts at 0).
      | If not given, a list of available diagnostics is printed.
      | It can also be an operation between several diagnostics.
@@ -236,9 +238,9 @@ Open a ParticleBinning diagnostic
 Open a Screen diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:method:: Screen(diagNumber=None, timesteps=None, subset=None, sum=None, units=[""], data_log=False, **kwargs)
+.. py:method:: Screen(diagNumber=None, timesteps=None, subset=None, sum=None, units=[""], data_log=False, data_transform=None, **kwargs)
 
-  * ``timesteps``, ``units``, ``data_log``, ``export_dir``: same as before.
+  * ``timesteps``, ``units``, ``data_log``, ``data_transform``, ``export_dir``: same as before.
   * ``diagNumber``, ``subset`` and ``sum``: identical to that of ParticleBinning diagnostics.
   * See also :ref:`otherkwargs`
 
@@ -253,9 +255,9 @@ Open a Screen diagnostic
 Open a RadiationSpectrum diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:method:: ParticleBinning(diagNumber=None, timesteps=None, subset=None, sum=None, units=[""], data_log=False, **kwargs)
+.. py:method:: ParticleBinning(diagNumber=None, timesteps=None, subset=None, sum=None, units=[""], data_log=False, data_transform=None, **kwargs)
 
-  * ``timesteps``, ``units``, ``data_log``, ``export_dir``: same as before.
+  * ``timesteps``, ``units``, ``data_log``, ``data_transform``, ``export_dir``: same as before.
   * ``diagNumber``, ``subset`` and ``sum``: identical to that of ParticleBinning diagnostics.
   * See also :ref:`otherkwargs`
 
@@ -331,9 +333,9 @@ The post-processing of the *performances* diagnostic may be achieved in three di
 modes: ``raw``, ``map``, or ``histogram``, described further below. You must choose one
 and only one mode between those three.
 
-.. py:method:: Performances(raw=None, map=None, histogram=None, timesteps=None, units=[""], data_log=False, species=None, **kwargs)
+.. py:method:: Performances(raw=None, map=None, histogram=None, timesteps=None, units=[""], data_log=False, data_transform=None, species=None, **kwargs)
 
-  * ``timesteps``, ``units``, ``data_log``, ``export_dir``: same as before.
+  * ``timesteps``, ``units``, ``data_log``, ``data_transform``, ``export_dir``: same as before.
   * ``raw`` : The name of a quantity, or an operation between them (see quantities below).
     The requested quantity is listed for each process.
   * ``map`` : The name of a quantity, or an operation between them (see quantities below).
@@ -442,6 +444,9 @@ to manipulate the plotting options:
 
 * ``figure``: The figure number that is passed to matplotlib.
 * ``vmin``, ``vmax``: data value limits.
+* ``vsym``: indicates that data is symmetric about zero. In the absence
+  of ``vmin`` and ``vmax``, sets them to ``[-1, 1]*max(abs(data))`` respectively.
+  Sets default colormap to ``smileiD``.
 * ``xmin``, ``xmax``, ``ymin``, ``ymax``: axes limits.
 * ``xfactor``, ``yfactor``: factors to rescale axes.
 * ``side``: ``"left"`` (by default) or ``"right"`` puts the y-axis on the left-
@@ -790,7 +795,7 @@ there are many more optional arguments. They are directly passed to the *matplot
   Please refer to
   `matplotlib's line options <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.plot>`_.
 
-.. rubric:: For the image: ``cmap``, ``aspect``, ``interpolation``
+.. rubric:: For the image: ``cmap``, ``aspect``, ``interpolation``, ``norm``
 
 ..
 
@@ -799,7 +804,7 @@ there are many more optional arguments. They are directly passed to the *matplot
 
 .. rubric:: For the colorbar: ``cbaspect``, ``orientation``, ``fraction``, ``pad``,
   ``shrink``, ``anchor``, ``panchor``, ``extend``, ``extendfrac``, ``extendrect``,
-  ``spacing``, ``ticks``, ``format``, ``drawedges``
+  ``spacing``, ``ticks``, ``format``, ``drawedges``, ``size``
 
 ..
 

--- a/doc/Sphinx/post-processing.rst
+++ b/doc/Sphinx/post-processing.rst
@@ -99,7 +99,7 @@ Open a Scalar diagnostic
   * ``data_log``:
      | If ``True``, then :math:`\log_{10}` is applied to the output.
   * ``data_transform``:
-     | If ``callable``, is applied to the output.
+     | If this is set to a function, the function is applied to the output before plotting.
   * See also :ref:`otherkwargs`
 
 **Example**::

--- a/happi/_Diagnostics/Diagnostic.py
+++ b/happi/_Diagnostics/Diagnostic.py
@@ -713,8 +713,11 @@ class Diagnostic(object):
 		self._setLimits(ax, xmin=self.options.xmin, xmax=self.options.xmax, ymin=self.options.ymin, ymax=self.options.ymax)
 		if 'cax' not in dir(ax):
 			ax.cax = {}
-		if "aspect" not in self.options.colorbar.keys() or self.options.colorbar["aspect"]>0:
-			ax.cax[cax_id] = ax.figure.colorbar(mappable=self._plot, ax=ax, use_gridspec=False, **self.options.colorbar)
+		if cax_id not in ax.cax and ("aspect" not in self.options.cax or self.options.cax["aspect"]>0):
+			from mpl_toolkits.axes_grid1 import make_axes_locatable
+			divider = make_axes_locatable(ax)
+			cax = divider.append_axes(**self.options.cax)
+			ax.cax[cax_id] = self._plt.colorbar(mappable=self._plot, cax=cax, **self.options.colorbar)
 		self._setTitle(ax, t)
 		self._setAxesOptions(ax)
 		self._setColorbarOptions(ax.cax[cax_id].ax)

--- a/happi/_Diagnostics/Diagnostic.py
+++ b/happi/_Diagnostics/Diagnostic.py
@@ -706,10 +706,6 @@ class Diagnostic(object):
 		self._plot = self._plotOnAxes_2D_(ax, A)
 		ax.set_xlabel(self._xlabel, self.options.labels_font["xlabel"])
 		ax.set_ylabel(self._ylabel, self.options.labels_font["ylabel"])
-		if self.options.vmin is None and self.options.vmax is None and self.options.vsym:
-			vmax = self._np.abs(A).max()
-			vmin = -1 * vmax
-			self._plot.set_clim(vmin, vmax)
 		self._setLimits(ax, xmin=self.options.xmin, xmax=self.options.xmax, ymin=self.options.ymin, ymax=self.options.ymax)
 		if 'cax' not in dir(ax):
 			ax.cax = {}
@@ -751,9 +747,14 @@ class Diagnostic(object):
 		self._setLimits(ax, xmin=self.options.xmin, xmax=self.options.xmax, ymin=self.options.ymin, ymax=self.options.ymax)
 		vmin = self.options.vmin
 		vmax = self.options.vmax
-		if vmin is None and vmax is None and self.options.vsym:
-			vmax = self._np.abs(A).max()
-			vmin = -1 * vmax
+		if self.options.vsym:
+			# Don't warn here, it will be annoying if every frame
+			if self.options.vsym is True:
+				vmax = self._np.abs(A).max()
+			else:
+				vmax = self._np.abs(self.options.vsym)
+
+			vmin = -vmax
 		if vmin is None: vmin = A.min()
 		if vmax is None: vmax = A.max()
 		self._plot.set_clim(vmin, vmax)
@@ -765,8 +766,20 @@ class Diagnostic(object):
 	# This is overloaded by class "Probe" because it requires to replace imshow
 	# Also overloaded by class "Performances" to add a line plot
 	def _plotOnAxes_2D_(self, ax, A):
+		vmin = self.options.vmin
+		vmax = self.options.vmax
+		if self.options.vsym:
+			if vmin or vmax:
+				print("WARNING: vsym set on the same Diagnostic as vmin and/or vmax. Ignoring vmin/vmax.")
+		        
+			if self.options.vsym is True:
+				vmax = self._np.abs(A).max()
+			else:
+				vmax = self._np.abs(self.options.vsym)
+
+			vmin = -vmax
 		self._plot = ax.imshow( self._np.rot90(A),
-			vmin = self.options.vmin, vmax = self.options.vmax, extent=self._extent, **self.options.image)
+			vmin = vmin, vmax = vmax, extent=self._extent, **self.options.image)
 		return self._plot
 	def _animateOnAxes_2D_(self, ax, A):
 		self._plot.set_data( self._np.rot90(A) )

--- a/happi/_Diagnostics/Diagnostic.py
+++ b/happi/_Diagnostics/Diagnostic.py
@@ -23,6 +23,7 @@ class Diagnostic(object):
 		self._units = []
 		self._log = []
 		self._data_log = False
+		self._data_transform = None
 		self._error = []
 		self._xoffset = 0.
 		

--- a/happi/_Diagnostics/Diagnostic.py
+++ b/happi/_Diagnostics/Diagnostic.py
@@ -706,6 +706,10 @@ class Diagnostic(object):
 		self._plot = self._plotOnAxes_2D_(ax, A)
 		ax.set_xlabel(self._xlabel, self.options.labels_font["xlabel"])
 		ax.set_ylabel(self._ylabel, self.options.labels_font["ylabel"])
+		if self.options.vmin is None and self.options.vmax is None and self.options.vsym:
+			vmax = self._np.abs(A).max()
+			vmin = -1 * vmax
+			self._plot.set_clim(vmin, vmax)
 		self._setLimits(ax, xmin=self.options.xmin, xmax=self.options.xmax, ymin=self.options.ymin, ymax=self.options.ymax)
 		if 'cax' not in dir(ax):
 			ax.cax = {}
@@ -739,8 +743,11 @@ class Diagnostic(object):
 		self._plot = self._animateOnAxes_2D_(ax, A)
 		self._setLimits(ax, xmin=self.options.xmin, xmax=self.options.xmax, ymin=self.options.ymin, ymax=self.options.ymax)
 		vmin = self.options.vmin
-		if vmin is None: vmin = A.min()
 		vmax = self.options.vmax
+		if vmin is None and vmax is None and self.options.vsym:
+			vmax = self._np.abs(A).max()
+			vmin = -1 * vmax
+		if vmin is None: vmin = A.min()
 		if vmax is None: vmax = A.max()
 		self._plot.set_clim(vmin, vmax)
 		ax.cax[cax_id].mappable.set_clim(vmin, vmax)

--- a/happi/_Diagnostics/Diagnostic.py
+++ b/happi/_Diagnostics/Diagnostic.py
@@ -714,8 +714,12 @@ class Diagnostic(object):
 		if 'cax' not in dir(ax):
 			ax.cax = {}
 		if cax_id not in ax.cax and ("aspect" not in self.options.cax or self.options.cax["aspect"]>0):
-			from mpl_toolkits.axes_grid1 import make_axes_locatable
-			divider = make_axes_locatable(ax)
+			try:
+				divider = ax.divider
+			except:
+				from mpl_toolkits.axes_grid1 import make_axes_locatable
+				divider = make_axes_locatable(ax)
+				ax.divider = divider
 			cax = divider.append_axes(**self.options.cax)
 			ax.cax[cax_id] = self._plt.colorbar(mappable=self._plot, cax=cax, **self.options.colorbar)
 		self._setTitle(ax, t)

--- a/happi/_Diagnostics/Diagnostic.py
+++ b/happi/_Diagnostics/Diagnostic.py
@@ -663,8 +663,7 @@ class Diagnostic(object):
 		if self.dim == 2 and self.options.transparent:
 			cmap = self.options.image["cmap"]
 			if type(cmap)==str: cmap = self._plt.matplotlib.cm.get_cmap(cmap)
-			d = cmap._segmentdata
-			new_cmap = self._plt.matplotlib.colors.LinearSegmentedColormap("tmp_cmap", cmap._segmentdata, N=256, gamma=1.0)
+			new_cmap = cmap.__copy__()
 			if self.options.transparent in ["both", "under"]:
 				new_cmap.set_under(color="white", alpha="0")
 			if self.options.transparent in ["both", "over"]:

--- a/happi/_Diagnostics/Field.py
+++ b/happi/_Diagnostics/Field.py
@@ -4,7 +4,7 @@ from .._Utils import *
 class Field(Diagnostic):
 	"""Class for loading a Field diagnostic"""
 	
-	def _init(self, diagNumber=None, field=None, timesteps=None, subset=None, average=None, data_log=False, moving=False, **kwargs):
+	def _init(self, diagNumber=None, field=None, timesteps=None, subset=None, average=None, data_log=False, data_transform=None, moving=False, **kwargs):
 		
 		self.moving = moving
 		self._subsetinfo = {}
@@ -171,7 +171,8 @@ class Field(Diagnostic):
 		
 		# Put data_log as object's variable
 		self._data_log = data_log
-		
+		self._data_transform = data_transform
+
 		# Case of a cylindrical geometry
 		# Check whether "theta" or "build3d" option is chosen
 		if self.cylindrical :
@@ -455,6 +456,8 @@ class Field(Diagnostic):
 				A = self._np.mean(A, axis=iaxis, keepdims=True)
 		# remove averaged axes
 		A = self._np.squeeze(A)
+		# transform if requested
+		if callable(self._data_transform): A = self._data_transform(A)
 		return A
 	
 	# Method to obtain the data only
@@ -505,6 +508,7 @@ class Field(Diagnostic):
 				A = self._np.mean(A, axis=iaxis, keepdims=True)
 		# remove averaged axes
 		A = self._np.squeeze(A)
+		if callable(self._data_transform): A = self._data_transform(A)
 		return A
 	
 	# Method to obtain the data only
@@ -552,4 +556,5 @@ class Field(Diagnostic):
 				A = self._np.mean(A, axis=iaxis, keepdims=True)
 		# remove averaged axes
 		A = self._np.squeeze(A)
+		if callable(self._data_transform): A = self._data_transform(A)
 		return A

--- a/happi/_Diagnostics/ParticleBinning.py
+++ b/happi/_Diagnostics/ParticleBinning.py
@@ -7,7 +7,7 @@ class ParticleBinning(Diagnostic):
 	_diagName = "ParticleBinning"
 	hasComposite = False
 	
-	def _init(self, diagNumber=None, timesteps=None, subset=None, sum=None, data_log=False, include={}, **kwargs):
+	def _init(self, diagNumber=None, timesteps=None, subset=None, sum=None, data_log=False, data_transform=None, include={}, **kwargs):
 		
 		# Search available diags
 		diag_numbers, diag_names = self.simulation.getDiags(self._diagName)
@@ -95,7 +95,8 @@ class ParticleBinning(Diagnostic):
 		
 		# Put data_log as object's variable
 		self._data_log = data_log
-		
+		self._data_transform = data_transform
+
 		# 2 - Manage timesteps
 		# -------------------------------------------------------------------
 		# Get available timesteps
@@ -483,4 +484,6 @@ class ParticleBinning(Diagnostic):
 				A = self._np.sum(A, axis=iaxis, keepdims=True)
 		# remove summed axes
 		A = self._np.squeeze(A)
+		# transform if requested
+		if callable(self._data_transform): A = self._data_transform(A)
 		return A

--- a/happi/_Diagnostics/Performances.py
+++ b/happi/_Diagnostics/Performances.py
@@ -71,7 +71,7 @@ def PartitionMatrix( matrix, listOfValues, oversize=0 ):
 class Performances(Diagnostic):
 	"""Class for loading a Performances diagnostic"""
 
-	def _init(self, raw=None, map=None, histogram=None, timesteps=None, data_log=False, species=None, **kwargs):
+	def _init(self, raw=None, map=None, histogram=None, timesteps=None, data_log=False, data_transform=None, species=None, **kwargs):
 
 		# Open the file(s) and load the data
 		self._h5items = {}
@@ -193,6 +193,7 @@ class Performances(Diagnostic):
 
 		# Put data_log as object's variable
 		self._data_log = data_log
+		self._data_transform = data_transform
 
 		# In case of "vecto" quantity, get the species
 		if species is not None:
@@ -353,6 +354,8 @@ class Performances(Diagnostic):
 		else:
 			A = eval(self._operation)
 		
+		if callable(self._data_transform): A = self._data_transform(A)
+
 		# If raw requested
 		if self._mode == "raw":
 			return A

--- a/happi/_Diagnostics/Probe.py
+++ b/happi/_Diagnostics/Probe.py
@@ -145,6 +145,7 @@ class Probe(Diagnostic):
 		self._averages = [False]*self._naxes
 		self._selection = [self._np.s_[:]]*self._naxes
 		p = []
+		self.p_plot = []
 		for iaxis in range(self._naxes):
 
 			# calculate grid points locations
@@ -196,6 +197,7 @@ class Probe(Diagnostic):
 					self._label  .append(label)
 					self._units  .append(axisunits)
 					self._log    .append(False)
+					self.p_plot  .append(p[-1])
 		
 		self._selection = tuple(s if type(s) is slice else slice(s,s+1) for s in self._selection)
 		
@@ -219,8 +221,8 @@ class Probe(Diagnostic):
 			# Trick in a 3D simulation (the probe has to be projected)
 			if self._ndim_particles==3:
 				# unit vectors in the two dimensions + perpendicular
-				u1 = p[0] / self._np.linalg.norm(p[0])
-				u2 = p[1] / self._np.linalg.norm(p[1])
+				u1 = self.p_plot[0] / self._np.linalg.norm(self.p_plot[0])
+				u2 = self.p_plot[1] / self._np.linalg.norm(self.p_plot[1])
 				# Distances along first direction
 				p1[:,0] = self._np.dot(p1, u1)
 				p1[:,1:] = 0.

--- a/happi/_Diagnostics/Probe.py
+++ b/happi/_Diagnostics/Probe.py
@@ -432,8 +432,20 @@ class Probe(Diagnostic):
 
 	# Overloading a plotting function in order to use pcolormesh instead of imshow
 	def _plotOnAxes_2D_(self, ax, A):
+		vmin = self.options.vmin
+		vmax = self.options.vmax
+		if self.options.vsym:
+			if vmin or vmax:
+				print("WARNING: vsym set on the same Diagnostic as vmin and/or vmax. Ignoring vmin/vmax.")
+		        
+			if self.options.vsym is True:
+				vmax = self._np.abs(A).max()
+			else:
+				vmax = self._np.abs(self.options.vsym)
+
+			vmin = -vmax
 		self._plot = ax.pcolormesh(self._xfactor*self._edges[0], self._yfactor*self._edges[1], (A),
-			vmin = self.options.vmin, vmax = self.options.vmax, **self.options.image)
+			vmin = vmin, vmax = vmax, **self.options.image)
 		return self._plot
 	def _animateOnAxes_2D_(self, ax, A):
 		self._plot.set_array( A.flatten() )

--- a/happi/_Diagnostics/Probe.py
+++ b/happi/_Diagnostics/Probe.py
@@ -4,7 +4,7 @@ from .._Utils import *
 class Probe(Diagnostic):
 	"""Class for loading a Probe diagnostic"""
 
-	def _init(self, probeNumber=None, field=None, timesteps=None, subset=None, average=None, data_log=False, chunksize=10000000, **kwargs):
+	def _init(self, probeNumber=None, field=None, timesteps=None, subset=None, average=None, data_log=False, chunksize=10000000, data_transform=None, **kwargs):
 
 		self._h5probe = []
 		self._alltimesteps = []
@@ -113,6 +113,7 @@ class Probe(Diagnostic):
 
 		# Put data_log as object's variable
 		self._data_log = data_log
+		self._data_transform = data_transform
 
 		# Get the shape of the probe
 		self._myinfo = self._getMyInfo()
@@ -413,6 +414,8 @@ class Probe(Diagnostic):
 			if self._averages[iaxis]:
 				A = self._np.mean(A, axis=iaxis, keepdims=True)
 		A = self._np.squeeze(A) # remove averaged axes
+
+		if callable(self._data_transform): A = self._data_transform(A)
 		return A
 
 	# We override _prepare4

--- a/happi/_Diagnostics/Scalar.py
+++ b/happi/_Diagnostics/Scalar.py
@@ -4,7 +4,7 @@ from .._Utils import *
 class Scalar(Diagnostic):
 	"""Class for loading a Scalar diagnostic"""
 	
-	def _init(self, scalar=None, timesteps=None, data_log=False, **kwargs):
+	def _init(self, scalar=None, timesteps=None, data_log=False, data_transform=None, **kwargs):
 		# Get available scalars
 		scalars = self.getScalars()
 		
@@ -42,6 +42,7 @@ class Scalar(Diagnostic):
 		
 		# Put data_log as object's variable
 		self._data_log = data_log
+		self._data_transform = data_transform
 		
 		# Already get the data from the file
 		# Loop file line by line
@@ -152,4 +153,6 @@ class Scalar(Diagnostic):
 			return []
 		# Get value at selected time
 		A = self._values[ self._data[t] ]
+
+		if callable(self._data_transform): A = self._data_transform(A)
 		return A

--- a/happi/_Utils.py
+++ b/happi/_Utils.py
@@ -121,6 +121,7 @@ class Options(object):
 		self.image = {"interpolation":"nearest", "aspect":"auto"}
 		self.colorbar = {}
 		self.colorbar_font = {}
+		self.cax = {"size": "5%", "pad": 0.15}
 		self.xtick = {"useOffset":False}
 		self.ytick = {"useOffset":False}
 		self.side = "left"
@@ -176,8 +177,11 @@ class Options(object):
 			# image
 			elif kwa in ["aspect","interpolation","norm"]:
 				self.image[kwa] = val
+			# colorbar axes
+			elif kwa in ["pad", "size"]:
+				self.cax[kwa] = val
 			# colorbar
-			elif kwa in ["orientation","fraction","pad","shrink","anchor","panchor",
+			elif kwa in ["orientation","fraction","shrink","anchor","panchor",
 					     "extend","extendfrac","extendrect","spacing","ticks","format",
 					     "drawedges"]:
 				self.colorbar[kwa] = val
@@ -193,9 +197,8 @@ class Options(object):
 			kwargs.pop(kwa)
 		# special case: "aspect" is ambiguous because it exists for both imshow and colorbar
 		if "cbaspect" in kwargs:
-			self.colorbar["aspect"] = kwargs.pop("cbaspect")
-		if self.side=="right" and "pad" not in self.colorbar:
-			self.colorbar["pad"] = 0.15
+			self.cax["aspect"] = kwargs.pop("cbaspect")
+		self.cax['position'] = 'bottom' if ( 'orientation' in self.colorbar and self.colorbar['orientation'] == 'horizontal' ) else 'right'
 		if self.explicit_cmap is None:
 			self.image['cmap'] = 'smileiD' if self.vsym else 'smilei'
 		else:

--- a/happi/_Utils.py
+++ b/happi/_Utils.py
@@ -170,7 +170,7 @@ class Options(object):
 					     "visible","zorder"]:
 				self.plot[kwa] = val
 			# image
-			elif kwa in ["cmap","aspect","interpolation"]:
+			elif kwa in ["cmap","aspect","interpolation","norm"]:
 				self.image[kwa] = val
 			# colorbar
 			elif kwa in ["orientation","fraction","pad","shrink","anchor","panchor",

--- a/happi/_Utils.py
+++ b/happi/_Utils.py
@@ -198,6 +198,8 @@ class Options(object):
 		# special case: "aspect" is ambiguous because it exists for both imshow and colorbar
 		if "cbaspect" in kwargs:
 			self.cax["aspect"] = kwargs.pop("cbaspect")
+		if "clabel" in kwargs:
+			self.colorbar["label"] = kwargs.pop("clabel")
 		self.cax['position'] = 'bottom' if ( 'orientation' in self.colorbar and self.colorbar['orientation'] == 'horizontal' ) else 'right'
 		if self.explicit_cmap is None:
 			self.image['cmap'] = 'smileiD' if self.vsym else 'smilei'

--- a/happi/_Utils.py
+++ b/happi/_Utils.py
@@ -105,9 +105,11 @@ class Options(object):
 		self.yfactor = None
 		self.ymin    = None
 		self.ymax    = None
+		self.vsym    = False
 		self.vfactor = None
 		self.vmin    = None
 		self.vmax    = None
+		self.explicit_cmap = None
 		self.figure0 = {}
 		self.figure1 = {"facecolor":"w"}
 		self.axes = {}
@@ -116,7 +118,7 @@ class Options(object):
 		self.ticklabels = {}
 		self.ticklabels_font = {}
 		self.plot = {}
-		self.image = {"cmap":"smilei", "interpolation":"nearest", "aspect":"auto"}
+		self.image = {"interpolation":"nearest", "aspect":"auto"}
 		self.colorbar = {}
 		self.colorbar_font = {}
 		self.xtick = {"useOffset":False}
@@ -138,6 +140,8 @@ class Options(object):
 		self.vfactor     = kwargs.pop("vfactor"    , self.vfactor  )
 		self.vmin        = kwargs.pop("vmin"       , self.vmin )
 		self.vmax        = kwargs.pop("vmax"       , self.vmax )
+		self.vsym        = kwargs.pop("vsym"       , self.vsym )
+		self.explicit_cmap = kwargs.pop("cmap"     , self.explicit_cmap )
 		self.side        = kwargs.pop("side"       , self.side )
 		self.transparent = kwargs.pop("transparent", self.transparent )
 		self.export_dir  = kwargs.pop("export_dir", self.export_dir )
@@ -170,7 +174,7 @@ class Options(object):
 					     "visible","zorder"]:
 				self.plot[kwa] = val
 			# image
-			elif kwa in ["cmap","aspect","interpolation","norm"]:
+			elif kwa in ["aspect","interpolation","norm"]:
 				self.image[kwa] = val
 			# colorbar
 			elif kwa in ["orientation","fraction","pad","shrink","anchor","panchor",
@@ -192,6 +196,10 @@ class Options(object):
 			self.colorbar["aspect"] = kwargs.pop("cbaspect")
 		if self.side=="right" and "pad" not in self.colorbar:
 			self.colorbar["pad"] = 0.15
+		if self.explicit_cmap is None:
+			self.image['cmap'] = 'smileiD' if self.vsym else 'smilei'
+		else:
+			self.image['cmap'] = self.explicit_cmap
 		return kwargs
 
 PintWarningIssued = False


### PR DESCRIPTION
Some minor changes to happi to improve the user experience somewhat (and small bug fixes for some probe diagnostics and the transparent option):
* 2D (image) plots can accept the `norm` kwarg now, enabling log plots with nice colorbars along with more unusual normalisations like power laws and symmetric log
* An argument `vsym` that lets the range of a color axis vary automatically according to the data being plotted (e.g. in an animation) but forces it to remain centred on zero
* Nicer behaviour of colorbars: they now fit to the height of the plot instead of changing their relative size as the window changes size, have settable labels (useful for multiPlot) and width/padding. Default padding isn't currently auto-adjusted for multiPlot instances to stop overlab of one colorbar with the other's label, though this may be doable if desired.
* Arbitrary callable `data_transform` on Diagnostics, which can e.g. apply a convolution kernel such as a Gaussian blur to data before plotting.

and the bug fixes:
* 3D Probes didn't behave properly when sliced over axis1 or axis2
* `transparent` option to multiPlot caused an error if the colormap in use wasn't a `LinearSegmentedColormap`; now works for any colormap class which defines a `__copy__()` method.