### PR TITLE
fix(happi): multiplot y-axis right side plotting

### DIFF
--- a/happi/_Utils.py
+++ b/happi/_Utils.py
@@ -499,7 +499,7 @@ class _multiPlotUtil(object):
 			c = self.plt.matplotlib.rcParams["axes.prop_cycle"].by_key()["color"]
 		rightside = [d.options.side=="right" for d in Diags]
 		self.allright  = all(rightside)
-		self.bothsides = any(rightside) and not allright
+		self.bothsides = any(rightside) and not self.allright
 		for i, Diag in enumerate(Diags):
 			Diag._cax_id = 0
 			if self.sameAxes:
@@ -508,7 +508,7 @@ class _multiPlotUtil(object):
 			else:
 				Diag._ax = self.ax[i]
 			if Diag.options.side == "right":
-				if self.sameAxes and not allright:
+				if self.sameAxes and not self.allright:
 					try   : Diag._ax.twin # check if twin exists
 					except: Diag._ax.twin = Diag._ax.twinx()
 					Diag._ax = Diag._ax.twin


### PR DESCRIPTION
Documentation for happi.multiPlot states the following:-

> One diagnostic may have the option side="right" to use the right-hand-side axis.

Attempting to use this functionality results in the following stack trace and produces an empty plot:-

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/Smilei/happi/_Utils.py", line 625, in multiPlot
    mp = _multiPlotUtil( *Diags, **kwargs )
  File "/path/to/Smilei/happi/_Utils.py", line 502, in __init__
    self.bothsides = any(rightside) and not allright
NameError: name 'allright' is not defined
```

This small PR resolves this and restores the functionality.