### PR TITLE
Time relativistic poisson solver

### DIFF
--- a/src/Patch/VectorPatch.cpp
+++ b/src/Patch/VectorPatch.cpp
@@ -904,7 +904,7 @@ void VectorPatch::computeChargeRelativisticSpecies( double time_primal )
         for( unsigned int ispec=0 ; ispec<( *this )( ipatch )->vecSpecies.size() ; ispec++ ) {
             // project only if species needs relativistic initialization and it is the right time to initialize its fields
             if( ( species( ipatch, ispec )->relativistic_field_initialization_ ) &&
-                    ( time_primal == species( ipatch, ispec )->time_relativistic_initialization_ ) ) {
+                    ( time_primal == species( ipatch, ispec )->iter_relativistic_initialization_ ) ) {
                 if( ( *this )( ipatch )->vecSpecies[ispec]->vectorized_operators ) {
                     species( ipatch, ispec )->computeCharge( ispec, emfields( ipatch ) );
                 } else {
@@ -2024,7 +2024,7 @@ void VectorPatch::solveRelativisticPoisson( Params &params, SmileiMPI *smpi, dou
     for( unsigned int ispec=0 ; ispec<( *this )( 0 )->vecSpecies.size() ; ispec++ ) {
         if( species( 0, ispec )->relativistic_field_initialization_ ) {
             for( unsigned int ipatch=0 ; ipatch<this->size() ; ipatch++ ) {
-                if( time_primal==species( ipatch, ispec )->time_relativistic_initialization_ ) {
+                if( time_primal==species( ipatch, ispec )->iter_relativistic_initialization_ ) {
                     s_gamma += species( ipatch, ispec )->sumGamma();
                     nparticles += species( ipatch, ispec )->getNbrOfParticles();
                 }
@@ -2451,7 +2451,7 @@ void VectorPatch::solveRelativisticPoissonAM( Params &params, SmileiMPI *smpi, d
     for( unsigned int ispec=0 ; ispec<( *this )( 0 )->vecSpecies.size() ; ispec++ ) {
         if( species( 0, ispec )->relativistic_field_initialization_ ) {
             for( unsigned int ipatch=0 ; ipatch<this->size() ; ipatch++ ) {
-                if( time_primal==species( ipatch, ispec )->time_relativistic_initialization_ ) {
+                if( time_primal==species( ipatch, ispec )->iter_relativistic_initialization_ ) {
                     s_gamma += species( ipatch, ispec )->sumGamma();
                     nparticles += species( ipatch, ispec )->getNbrOfParticles();
                 }

--- a/src/Patch/VectorPatch.cpp
+++ b/src/Patch/VectorPatch.cpp
@@ -896,7 +896,7 @@ void VectorPatch::computeCharge(bool old /*=false*/)
 
 } // END computeRho
 
-void VectorPatch::computeChargeRelativisticSpecies( double time_primal )
+void VectorPatch::computeChargeRelativisticSpecies( double time_primal, Params &params )
 {
     #pragma omp for schedule(runtime)
     for( unsigned int ipatch=0 ; ipatch<this->size() ; ipatch++ ) {
@@ -904,7 +904,7 @@ void VectorPatch::computeChargeRelativisticSpecies( double time_primal )
         for( unsigned int ispec=0 ; ispec<( *this )( ipatch )->vecSpecies.size() ; ispec++ ) {
             // project only if species needs relativistic initialization and it is the right time to initialize its fields
             if( ( species( ipatch, ispec )->relativistic_field_initialization_ ) &&
-                    ( time_primal == species( ipatch, ispec )->iter_relativistic_initialization_ ) ) {
+                    ( (int)(time_primal/params.timestep) == species( ipatch, ispec )->iter_relativistic_initialization_ ) ) {
                 if( ( *this )( ipatch )->vecSpecies[ispec]->vectorized_operators ) {
                     species( ipatch, ispec )->computeCharge( ispec, emfields( ipatch ) );
                 } else {
@@ -1967,7 +1967,7 @@ void VectorPatch::runNonRelativisticPoissonModule( Params &params, SmileiMPI* sm
 void VectorPatch::runRelativisticModule( double time_prim, Params &params, SmileiMPI* smpi,  Timers &timers )
 {
     // Compute rho only for species needing relativistic field Initialization
-    computeChargeRelativisticSpecies( time_prim );
+    computeChargeRelativisticSpecies( time_prim, params );
 
     if (params.geometry != "AMcylindrical"){
         SyncVectorPatch::sum<double,Field>( listrho_, (*this), smpi, timers, 0 );
@@ -2024,7 +2024,7 @@ void VectorPatch::solveRelativisticPoisson( Params &params, SmileiMPI *smpi, dou
     for( unsigned int ispec=0 ; ispec<( *this )( 0 )->vecSpecies.size() ; ispec++ ) {
         if( species( 0, ispec )->relativistic_field_initialization_ ) {
             for( unsigned int ipatch=0 ; ipatch<this->size() ; ipatch++ ) {
-                if( time_primal==species( ipatch, ispec )->iter_relativistic_initialization_ ) {
+                if( (int)(time_primal/params.timestep)==species( ipatch, ispec )->iter_relativistic_initialization_ ) {
                     s_gamma += species( ipatch, ispec )->sumGamma();
                     nparticles += species( ipatch, ispec )->getNbrOfParticles();
                 }
@@ -2451,7 +2451,7 @@ void VectorPatch::solveRelativisticPoissonAM( Params &params, SmileiMPI *smpi, d
     for( unsigned int ispec=0 ; ispec<( *this )( 0 )->vecSpecies.size() ; ispec++ ) {
         if( species( 0, ispec )->relativistic_field_initialization_ ) {
             for( unsigned int ipatch=0 ; ipatch<this->size() ; ipatch++ ) {
-                if( time_primal==species( ipatch, ispec )->iter_relativistic_initialization_ ) {
+                if( (int)(time_primal/params.timestep)==species( ipatch, ispec )->iter_relativistic_initialization_ ) {
                     s_gamma += species( ipatch, ispec )->sumGamma();
                     nparticles += species( ipatch, ispec )->getNbrOfParticles();
                 }

--- a/src/Patch/VectorPatch.h
+++ b/src/Patch/VectorPatch.h
@@ -148,7 +148,7 @@ public :
                                Timers &timers, int itime );
                                
     // compute rho only given by relativistic species which require initialization of the relativistic fields
-    void computeChargeRelativisticSpecies( double time_primal );
+    void computeChargeRelativisticSpecies( double time_primal, Params &params );
     
     // run particles ponderomptive dynamics, envelope's solver
     void runEnvelopeModule( Params &params,

--- a/src/Python/pyinit.py
+++ b/src/Python/pyinit.py
@@ -370,7 +370,6 @@ class Species(SmileiComponent):
     time_frozen = 0.0
     radiating = False
     relativistic_field_initialization = False
-    iter_relativistic_initialization = 0
     boundary_conditions = [["periodic"]]
     ionization_model = "none"
     ionization_electrons = None

--- a/src/Python/pyinit.py
+++ b/src/Python/pyinit.py
@@ -370,7 +370,7 @@ class Species(SmileiComponent):
     time_frozen = 0.0
     radiating = False
     relativistic_field_initialization = False
-    time_relativistic_initialization = 0.0
+    iter_relativistic_initialization = 0
     boundary_conditions = [["periodic"]]
     ionization_model = "none"
     ionization_electrons = None

--- a/src/Species/Species.cpp
+++ b/src/Species/Species.cpp
@@ -57,7 +57,7 @@ Species::Species( Params &params, Patch *patch ) :
     time_frozen_( 0 ),
     radiating_( false ),
     relativistic_field_initialization_( false ),
-    time_relativistic_initialization_( 0 ),
+    iter_relativistic_initialization_( 0 ),
     multiphoton_Breit_Wheeler_( 2, "" ),
     ionization_model( "none" ),
     density_profile_type_( "none" ),

--- a/src/Species/Species.h
+++ b/src/Species/Species.h
@@ -102,7 +102,7 @@ public:
     bool relativistic_field_initialization_;
 
     //! Iteration for which the species field is initialized in case of relativistic initialization
-    iter iter_relativistic_initialization_;
+    int iter_relativistic_initialization_;
 
     //! electron and positron Species for the multiphoton Breit-Wheeler
     std::vector<std::string> multiphoton_Breit_Wheeler_;

--- a/src/Species/Species.h
+++ b/src/Species/Species.h
@@ -102,7 +102,7 @@ public:
     bool relativistic_field_initialization_;
 
     //! Time for which the species field is initialized in case of relativistic initialization
-    double time_relativistic_initialization_;
+    double iter_relativistic_initialization_;
 
     //! electron and positron Species for the multiphoton Breit-Wheeler
     std::vector<std::string> multiphoton_Breit_Wheeler_;

--- a/src/Species/Species.h
+++ b/src/Species/Species.h
@@ -101,8 +101,8 @@ public:
     //! logical true if particles are relativistic and require proper electromagnetic field initialization
     bool relativistic_field_initialization_;
 
-    //! Time for which the species field is initialized in case of relativistic initialization
-    double iter_relativistic_initialization_;
+    //! Iteration for which the species field is initialized in case of relativistic initialization
+    iter iter_relativistic_initialization_;
 
     //! electron and positron Species for the multiphoton Breit-Wheeler
     std::vector<std::string> multiphoton_Breit_Wheeler_;

--- a/src/Species/SpeciesFactory.h
+++ b/src/Species/SpeciesFactory.h
@@ -665,7 +665,7 @@ public:
         }
         // time when the relativistic field initialization is applied, if enabled
         int n_timesteps_relativistic_initialization   = ( int )( this_species->time_frozen_/params.timestep );
-        this_species->time_relativistic_initialization_ = ( double )( n_timesteps_relativistic_initialization ) * params.timestep;
+        this_species->iter_relativistic_initialization_ = ( double )( n_timesteps_relativistic_initialization ) * params.timestep;
 
         if( !PyTools::extractVV( "boundary_conditions", this_species->boundary_conditions, "Species", ispec ) ) {
             ERROR( "For species '" << species_name << "', boundary_conditions not defined" );
@@ -983,7 +983,7 @@ public:
         new_species->time_frozen_                              = species->time_frozen_;
         new_species->radiating_                                = species->radiating_;
         new_species->relativistic_field_initialization_        = species->relativistic_field_initialization_;
-        new_species->time_relativistic_initialization_         = species->time_relativistic_initialization_;
+        new_species->iter_relativistic_initialization_         = species->iter_relativistic_initialization_;
         new_species->boundary_conditions                      = species->boundary_conditions;
         new_species->thermal_boundary_temperature_             = species->thermal_boundary_temperature_;
         new_species->thermal_boundary_velocity_                = species->thermal_boundary_velocity_;

--- a/src/Species/SpeciesFactory.h
+++ b/src/Species/SpeciesFactory.h
@@ -664,8 +664,7 @@ public:
             }
         }
         // time when the relativistic field initialization is applied, if enabled
-        int n_timesteps_relativistic_initialization   = ( int )( this_species->time_frozen_/params.timestep );
-        this_species->iter_relativistic_initialization_ = ( double )( n_timesteps_relativistic_initialization ) * params.timestep;
+        this_species->iter_relativistic_initialization_ = ( int )( this_species->time_frozen_/params.timestep );
 
         if( !PyTools::extractVV( "boundary_conditions", this_species->boundary_conditions, "Species", ispec ) ) {
             ERROR( "For species '" << species_name << "', boundary_conditions not defined" );


### PR DESCRIPTION
In this branch a bug fix for Issue #420 is implemented. The changes perform a safer check on the time when relativistic Poisson's solver must be called for a given `Species` with relativistic initialization enabled (a check on an int instead of a float). 