### PR TITLE
Added ARCHER2 machine script

### DIFF
--- a/scripts/compile_tools/machine/archer2
+++ b/scripts/compile_tools/machine/archer2
@@ -1,0 +1,48 @@
+#
+# Machine script for ARCHER2
+# --------------------------
+#
+# Clone Smilei to your directory in the /work filesystem
+#
+# # Set up environment:
+#
+# module restore PrgEnv-gnu
+# export CXX=CC
+# module load cray-python
+# module load cray-hdf5-parallel
+# export PYTHONHOME=/opt/cray/pe/python/3.8.5.0/
+# export LD_LIBRARY_PATH=/opt/cray/pe/python/3.8.5.0/lib:$LD_LIBRARY_PATH
+# export LIBRARY_PATH=$LIBRARY_PATH:/opt/cray/pe/python/3.8.5.0/lib
+# export PATH=/opt/cray/pe/python/3.8.5.0/lib:$PATH
+#
+SMILEICXX=CC
+CXXFLAGS += -O3 -march=znver2 -fopenmp
+#
+# # Compile:
+#
+# make -j 32 machine=archer2
+#
+# Example job script (replace items in <BRACKETS>):
+#
+#```
+##!/bin/bash
+##SBATCH --job-name=smilei
+##SBATCH --time=00:10:00
+##SBATCH --nodes=1
+##SBATCH --tasks-per-node=2
+##SBATCH --cpus-per-task=64
+##SBATCH --account=<ACCOUNT>
+##SBATCH --partition=standard
+##SBATCH --qos=standard
+#
+#module load epcc-job-env
+#module load cray-python
+#module load cray-hdf5-parallel
+#export LD_LIBRARY_PATH=/opt/cray/pe/python/3.8.5.0/lib:$LD_LIBRARY_PATH
+#
+#export OMP_NUM_THREADS=64
+#export OMP_PLACES=cores
+#export OMP_SCHEDULE=dynamic
+#
+#srun --hint=nomultithread --distribution=block:block </PATH/TO/SMILEI>/smilei <SMILEI_NAMELIST>.py
+#```


### PR DESCRIPTION
Added machine script for compilation on [ARCHER2](https://www.archer2.ac.uk/). Tested with the following simulations on the ARCHER2-4c service:

- `tst1d_02_two_str_instability`
- `tst2d_04_laser_wake.py`
- An extended 2D LWFA simulation with  high resolution (40 cells per laser wavelength, 512 particles per cell, 8 nodes).
- Other physical benchmarks against known results from the EPOCH PIC code.

I've not yet been able to test vectorisation, but there may be some subtlety getting things running smoothly with the AMD chips.

Side note: I ran some performance benchmarks, and the optimal thread/process/patch configuration is currently unclear to me. I would expect peak performance when the number of MPI processes per node matches the number of NUMA regions per node (8), but this is not the case. In the tests I ran, the best number of tasks per node was 32, with 4 cpus (and threads) per task. If I have time, I'll investigate further.