### PR TITLE
Update cori_hsw

### DIFF
--- a/scripts/compile_tools/machine/cori_hsw
+++ b/scripts/compile_tools/machine/cori_hsw
@@ -1,8 +1,17 @@
 SMILEICXX = CC
-HDF5_ROOT_DIR = /opt/cray/pe/hdf5-parallel/1.10.0/INTEL/15.0
-#PYTHONHOME = /global/common/cori/software/python/2.7-anaconda
+# module load cray-hdf5-parallel
+# module load boost
+# module load python3
+
+HDF5_ROOT_DIR = ${HDF5_ROOT}
+PYTHONHOME = ${PYTHON_DIR}
 LDFLAGS += -dynamic
-LDFLAGS += -L/opt/cray/pe/hdf5-parallel/1.10.0/INTEL/15.0/lib -lhdf5
+LDFLAGS += -L${CRAY_LD_LIBRARY_PATH} -lhdf5
+CXXFLAGS += -ip -ipo -inline-factor=1000 -qopt-zmm-usage=high -fno-alias -D__INTEL_HSW_E5_2680_v3
+
+#HDF5_ROOT_DIR = /opt/cray/pe/hdf5-parallel/1.10.0/INTEL/15.0
+#PYTHONHOME = /global/common/cori/software/python/2.7-anaconda
+#LDFLAGS += -L/opt/cray/pe/hdf5-parallel/1.10.0/INTEL/15.0/lib -lhdf5
 #LDFLAGS += -L/global/common/cori/software/python/2.7-anaconda/lib -lpython2.7
 #CXXFLAGS += -I/opt/cray/pe/hdf5-parallel/1.10.0/INTEL/15.0/include
 #CXXFLAGS += -I/global/common/cori/software/python/2.7-anaconda/include


### PR DESCRIPTION
Updated paths, as these versions either don't have the same paths or they don't exist on cori anymore. Paths are obtained from environment variables supplied by module commands.