### PR TITLE
Add compilation support for Apple M1 chips

### DIFF
--- a/src/Tools/backward.hpp
+++ b/src/Tools/backward.hpp
@@ -2218,6 +2218,8 @@ public:
 		error_addr = reinterpret_cast<void*>(uctx->uc_mcontext.gregs[REG_EIP]);
 #elif defined(__arm__)
 		error_addr = reinterpret_cast<void*>(uctx->uc_mcontext.arm_pc);
+#elif defined(__APPLE__) && defined(__aarch64__)
+		error_addr = reinterpret_cast<void*>(uctx->uc_mcontext->__ss.__pc);
 #elif defined(__aarch64__)
 		error_addr = reinterpret_cast<void*>(uctx->uc_mcontext.pc);
 #elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__)


### PR DESCRIPTION
Tested compiling for Apple macOS Monterey. This is similar to https://github.com/bombela/backward-cpp/issues/200