### PR TITLE
Avoid redundant h5py calls in TrackParticles' _init()

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -1,0 +1,20 @@
+name: check_docs
+
+on:
+  push:
+    branches: [ master, develop, CI ]
+  pull_request:
+    branches: [ master, develop, CI ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Build doc
+      run: |
+        sudo apt-get --allow-releaseinfo-change update -y 
+        sudo apt-get install -y git make sphinx
+        make -C doc/Sphinx html

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -1,8 +1,6 @@
 name: check_docs
 
 on:
-  push:
-    branches: [ master, develop, CI ]
   pull_request:
     branches: [ master, develop, CI ]
 

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -2,9 +2,8 @@ name: docs
 
 on:
   push:
-    branches: [ master, develop, CI ]
-  pull_request:
-    branches: [ master, develop, CI ]
+    branches:    
+      - master
 
 jobs:
   build:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -2,8 +2,9 @@ name: docs
 
 on:
   push:
-    branches:    
-      - master
+    branches: [ master, develop, CI ]
+  pull_request:
+    branches: [ master, develop, CI ]
 
 jobs:
   build:

--- a/happi/_Diagnostics/TrackParticles.py
+++ b/happi/_Diagnostics/TrackParticles.py
@@ -61,9 +61,9 @@ class TrackParticles(Diagnostic):
 			with self._h5py.File(file, "r") as f:
 				data = f["data"]
 				for t in data:
-					attrs = data[t].attrs
-					if "x_moved" in attrs:
-						self._XmovedForTime[int(t)] = attrs["x_moved"]
+					x_moved = data[t].attrs.get("x_moved")
+					if x_moved is not None:
+						self._XmovedForTime[int(t)] = x_moved
 		extra_properties = ["moving_x"] if self._XmovedForTime else []
 		
 		# If sorting allowed, find out if ordering needed

--- a/happi/_Diagnostics/TrackParticles.py
+++ b/happi/_Diagnostics/TrackParticles.py
@@ -59,9 +59,11 @@ class TrackParticles(Diagnostic):
 		self._XmovedForTime = {}
 		for file in disorderedfiles:
 			with self._h5py.File(file, "r") as f:
-				for t in f["data"]:
-					if "x_moved" in f["data"][t].attrs:
-						self._XmovedForTime[int(t)] = f["data"][t].attrs["x_moved"]
+				data = f["data"]
+				for t in data:
+					attrs = data[t].attrs
+					if "x_moved" in attrs:
+						self._XmovedForTime[int(t)] = attrs["x_moved"]
 		extra_properties = ["moving_x"] if self._XmovedForTime else []
 		
 		# If sorting allowed, find out if ordering needed

--- a/happi/_Diagnostics/TrackParticles.py
+++ b/happi/_Diagnostics/TrackParticles.py
@@ -59,9 +59,8 @@ class TrackParticles(Diagnostic):
 		self._XmovedForTime = {}
 		for file in disorderedfiles:
 			with self._h5py.File(file, "r") as f:
-				data = f["data"]
-				for t in data:
-					x_moved = data[t].attrs.get("x_moved")
+				for t, val in f["data"].items():
+					x_moved = val.attrs.get("x_moved")
 					if x_moved is not None:
 						self._XmovedForTime[int(t)] = x_moved
 		extra_properties = ["moving_x"] if self._XmovedForTime else []


### PR DESCRIPTION
This provides a ~10% perf improvement on the PALLAS workload that I've been profiling previously (see #622)