### PR TITLE
Updated compilation instructions for ARCHER2

### DIFF
--- a/scripts/compile_tools/machine/archer2
+++ b/scripts/compile_tools/machine/archer2
@@ -6,21 +6,19 @@
 #
 # # Set up environment:
 #
-# module restore PrgEnv-gnu
+# module restore
+# module load PrgEnv-gnu
 # export CXX=CC
 # module load cray-python
 # module load cray-hdf5-parallel
-# export PYTHONHOME=/opt/cray/pe/python/3.8.5.0/
-# export LD_LIBRARY_PATH=/opt/cray/pe/python/3.8.5.0/lib:$LD_LIBRARY_PATH
-# export LIBRARY_PATH=$LIBRARY_PATH:/opt/cray/pe/python/3.8.5.0/lib
-# export PATH=/opt/cray/pe/python/3.8.5.0/lib:$PATH
+# export LIBRARY_PATH=$LD_LIBRARY_PATH
 #
 SMILEICXX=CC
 CXXFLAGS += -O3 -march=znver2 -fopenmp
 #
 # # Compile:
 #
-# make -j 32 machine=archer2
+# make -j 8 machine=archer2
 #
 # Example job script (replace items in <BRACKETS>):
 #
@@ -38,11 +36,11 @@ CXXFLAGS += -O3 -march=znver2 -fopenmp
 #module load epcc-job-env
 #module load cray-python
 #module load cray-hdf5-parallel
-#export LD_LIBRARY_PATH=/opt/cray/pe/python/3.8.5.0/lib:$LD_LIBRARY_PATH
 #
 #export OMP_NUM_THREADS=64
 #export OMP_PLACES=cores
 #export OMP_SCHEDULE=dynamic
+#export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 #
 #srun --hint=nomultithread --distribution=block:block </PATH/TO/SMILEI>/smilei <SMILEI_NAMELIST>.py
 #```


### PR DESCRIPTION
Hi,

I'm a member of the CSE team for ARCHER2, one of our users has asked for instructions on how to install Smilei on our system after our [software upgrade](https://docs.archer2.ac.uk/faq/upgrade-2023/), so I've taken the opportunity to update your compilation script -- thank you for providing this, by the way.

Cray's python module was changed to support python 3.9, and it is now [much simpler to add packages](https://docs.archer2.ac.uk/user-guide/python/#installing-your-own-python-packages-with-pip) on top of the system installation.

I've removed a couple of the exports, since the `module load cray-python` action already does the same, and I added a new export to the job script that passes the value of `SLURM_CPUS_PER_TASK` to `SRUN`, since it [doesn't inherit it by default anymore](https://docs.archer2.ac.uk/faq/upgrade-2023/#slurm-cpus-per-task-setting-no-longer-inherited-by-srun).

Setting `PYTHONHOME` was preventing the software from running, and without it, it seems to be running fine (on my limited testing).

I reduced the number of cores used in the `make` command, to reduce the possibility of a user overwhelm one of our login nodes with such a command, as they are a shared resource.