### PR TITLE
Change makefile for GNU make > 4.3

### DIFF
--- a/makefile
+++ b/makefile
@@ -299,7 +299,7 @@ $(BUILD_DIR)/%.pyh: %.py
 
 # Calculate dependencies
 $(BUILD_DIR)/%.d: $(PYHEADERS) %.cpp
-	@echo "Checking dependencies for $@"
+	@echo "Checking dependencies for $*.cpp"
 	$(Q) if [ ! -d "$(@D)" ]; then mkdir -p "$(@D)"; fi;
 	$(Q) $(SMILEICXX) $(CXXFLAGS) -MF"$@" -MM -MP -MT"$@ $(@:.d=.o)" $*.cpp
 

--- a/makefile
+++ b/makefile
@@ -305,9 +305,9 @@ $(BUILD_DIR)/%.d: %.cpp
 
 # Calculate dependencies: special for Params.cpp which needs pyh files
 $(BUILD_DIR)/src/Params/Params.d: src/Params/Params.cpp $(PYHEADERS)
-        @echo "Checking dependencies for $<"
-        $(Q) if [ ! -d "$(@D)" ]; then mkdir -p "$(@D)"; fi;
-        $(Q) $(SMILEICXX) $(CXXFLAGS) -MF"$@" -MM -MP -MT"$@ $(@:.d=.o)" $<
+	@echo "Checking dependencies for $<"
+	$(Q) if [ ! -d "$(@D)" ]; then mkdir -p "$(@D)"; fi;
+	$(Q) $(SMILEICXX) $(CXXFLAGS) -MF"$@" -MM -MP -MT"$@ $(@:.d=.o)" $<
 
 ifeq ($(findstring icpc, $(COMPILER_INFO)), icpc)
 

--- a/makefile
+++ b/makefile
@@ -258,7 +258,7 @@ endif
 
 EXEC = smilei
 
-default: $(PYHEADERS) $(DEPS) $(EXEC) $(EXEC)_test
+default: $(PYHEADERS) $(EXEC) $(EXEC)_test
 
 #-----------------------------------------------------
 # Header
@@ -298,10 +298,10 @@ $(BUILD_DIR)/%.pyh: %.py
 	$(Q) $(PYTHONEXE) scripts/compile_tools/hexdump.py "$<" "$@"
 
 # Calculate dependencies
-$(BUILD_DIR)/%.d: %.cpp
-	@echo "Checking dependencies for $<"
+$(BUILD_DIR)/%.d: $(PYHEADERS) %.cpp
+	@echo "Checking dependencies for $@"
 	$(Q) if [ ! -d "$(@D)" ]; then mkdir -p "$(@D)"; fi;
-	$(Q) $(SMILEICXX) $(CXXFLAGS) -MF"$@" -MM -MP -MT"$@ $(@:.d=.o)" $<
+	$(Q) $(SMILEICXX) $(CXXFLAGS) -MF"$@" -MM -MP -MT"$@ $(@:.d=.o)" $*.cpp
 
 ifeq ($(findstring icpc, $(COMPILER_INFO)), icpc)
 
@@ -341,9 +341,15 @@ $(EXEC)_test : $(OBJS:Smilei.o=Smilei_test.o)
 	$(Q) $(SMILEICXX) $(OBJS:Smilei.o=Smilei_test.o) -o $(BUILD_DIR)/$@ $(LDFLAGS)
 	$(Q) cp $(BUILD_DIR)/$@ $@
 
-
 # these are not file-related rules
-.PHONY: clean distclean help env debug doc tar happi uninstall_happi
+PHONY_RULES=clean distclean help env debug doc tar happi uninstall_happi
+.PHONY: $(PHONY_RULES)
+
+# Check dependencies only when necessary
+GOALS = $(if $(MAKECMDGOALS), $(MAKECMDGOALS), default)
+ifneq ($(filter-out $(PHONY_RULES) print-%, $(GOALS)),)
+    -include $(DEPS)
+endif
 
 #-----------------------------------------------------
 # Doc rules

--- a/makefile
+++ b/makefile
@@ -298,10 +298,16 @@ $(BUILD_DIR)/%.pyh: %.py
 	$(Q) $(PYTHONEXE) scripts/compile_tools/hexdump.py "$<" "$@"
 
 # Calculate dependencies
-$(BUILD_DIR)/%.d: $(PYHEADERS) %.cpp
-	@echo "Checking dependencies for $*.cpp"
+$(BUILD_DIR)/%.d: %.cpp
+	@echo "Checking dependencies for $<"
 	$(Q) if [ ! -d "$(@D)" ]; then mkdir -p "$(@D)"; fi;
-	$(Q) $(SMILEICXX) $(CXXFLAGS) -MF"$@" -MM -MP -MT"$@ $(@:.d=.o)" $*.cpp
+	$(Q) $(SMILEICXX) $(CXXFLAGS) -MF"$@" -MM -MP -MT"$@ $(@:.d=.o)" $<
+
+# Calculate dependencies: special for Params.cpp which needs pyh files
+$(BUILD_DIR)/src/Params/Params.d: src/Params/Params.cpp $(PYHEADERS)
+        @echo "Checking dependencies for $<"
+        $(Q) if [ ! -d "$(@D)" ]; then mkdir -p "$(@D)"; fi;
+        $(Q) $(SMILEICXX) $(CXXFLAGS) -MF"$@" -MM -MP -MT"$@ $(@:.d=.o)" $<
 
 ifeq ($(findstring icpc, $(COMPILER_INFO)), icpc)
 

--- a/makefile
+++ b/makefile
@@ -258,7 +258,7 @@ endif
 
 EXEC = smilei
 
-default: $(EXEC) $(EXEC)_test
+default: $(PYHEADERS) $(DEPS) $(EXEC) $(EXEC)_test
 
 #-----------------------------------------------------
 # Header
@@ -341,19 +341,9 @@ $(EXEC)_test : $(OBJS:Smilei.o=Smilei_test.o)
 	$(Q) $(SMILEICXX) $(OBJS:Smilei.o=Smilei_test.o) -o $(BUILD_DIR)/$@ $(LDFLAGS)
 	$(Q) cp $(BUILD_DIR)/$@ $@
 
-# Avoid to check dependencies and to create .pyh if not necessary
-FILTER_RULES=clean distclean help env debug doc tar happi uninstall_happi
-ifeq ($(filter-out $(wildcard print-*),$(MAKECMDGOALS)),)
-    ifeq ($(filter $(FILTER_RULES),$(MAKECMDGOALS)),)
-        # Let's try to make the next lines clear: we include $(DEPS) and pygenerator
-        -include $(DEPS) pygenerator
-        # and pygenerator will create all the $(PYHEADERS) (which are files)
-        pygenerator : $(PYHEADERS)
-    endif
-endif
 
 # these are not file-related rules
-.PHONY: pygenerator $(FILTER_RULES)
+.PHONY: clean distclean help env debug doc tar happi uninstall_happi
 
 #-----------------------------------------------------
 # Doc rules


### PR DESCRIPTION
GNU make now does not remake phony makefiles. This is bad for us because the `pygenerator` was considered as a phony makefile, thus is now discarded, and the `.pyh` files are not made.

The pull request adds these files (`$(PYHEADERS)`) as requirements for the dependencies. When dependencies are made, the `pyh` files are made first.

Should solve #645 