### PR TITLE
Make IonizationTunnelEnvelopeAveraged inherit from IonizationTunnel

### DIFF
--- a/src/Ionization/Ionization.cpp
+++ b/src/Ionization/Ionization.cpp
@@ -14,11 +14,7 @@ Ionization::Ionization(Params &params, Species *species)
     nDim_particle = params.nDim_particle;
     ionized_species_invmass = 1. / species->mass_;
 
-    // Normalization constant from Smilei normalization to/from atomic units
-    eV_to_au   = 1.0 / 27.2116;
-    au_to_mec2 = 27.2116/510.998e3;
     EC_to_au   = 3.314742578e-15 * reference_angular_frequency_SI; // hbar omega / (me c^2 alpha^3)
     au_to_w0   = 4.134137172e+16 / reference_angular_frequency_SI; // alpha^2 me c^2 / (hbar omega)
-    
 }
 

--- a/src/Ionization/Ionization.cpp
+++ b/src/Ionization/Ionization.cpp
@@ -22,6 +22,3 @@ Ionization::Ionization(Params &params, Species *species)
     
 }
 
-Ionization::~Ionization()
-{
-}

--- a/src/Ionization/Ionization.cpp
+++ b/src/Ionization/Ionization.cpp
@@ -1,7 +1,5 @@
 #include "Ionization.h"
 
-#include <vector>
-
 #include "Species.h"
 
 using namespace std;

--- a/src/Ionization/Ionization.h
+++ b/src/Ionization/Ionization.h
@@ -22,9 +22,7 @@ public:
     virtual ~Ionization();
 
     //! Overloading of () operator
-    virtual void operator()(Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *, int = 0) {};
-    //! method for envelope ionization
-    virtual void envelopeIonization( Particles *, unsigned int, unsigned int, std::vector<double> *, std::vector<double> *, std::vector<double> *, std::vector<double> *, Patch *, Projector *, int = 0, int = 0 ){};
+    virtual void operator()(Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *) {};
 
     Particles new_electrons;
     

--- a/src/Ionization/Ionization.h
+++ b/src/Ionization/Ionization.h
@@ -1,15 +1,11 @@
 #ifndef IONIZATION_H
 #define IONIZATION_H
 
-#include <functional>
-#include <map>
-
 #include "Field.h"
 #include "Params.h"
 #include "Particles.h"
 #include "Patch.h"
 #include "Projector.h"
-#include "Tools.h"
 
 using namespace std;
 

--- a/src/Ionization/Ionization.h
+++ b/src/Ionization/Ionization.h
@@ -28,8 +28,9 @@ public:
     std::vector<short> ion_charge_;
 
 protected:
-    double eV_to_au;
-    double au_to_mec2;
+    // Normalization constant from Smilei normalization to/from atomic units
+    static constexpr double eV_to_au = 1.0 / 27.2116;
+    static constexpr double au_to_mec2 = 27.2116/510.998e3;
     double EC_to_au;
     double au_to_w0;
 
@@ -39,10 +40,6 @@ protected:
     unsigned int nDim_field;
     unsigned int nDim_particle;
     double ionized_species_invmass;
-
-private:
-
-
 };
 
 #endif

--- a/src/Ionization/Ionization.h
+++ b/src/Ionization/Ionization.h
@@ -15,7 +15,7 @@ class Ionization
 public:
     //! Constructor for Ionization
     Ionization(Params &params, Species *species);
-    virtual ~Ionization();
+    virtual ~Ionization() {};
 
     //! Overloading of () operator
     virtual void operator()(Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *) {};

--- a/src/Ionization/Ionization.h
+++ b/src/Ionization/Ionization.h
@@ -22,7 +22,7 @@ public:
     virtual ~Ionization();
 
     //! Overloading of () operator
-    virtual void operator()(Particles *, unsigned int, unsigned int, std::vector<double> *, Patch *, Projector *, int = 0) {};
+    virtual void operator()(Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *, int = 0) {};
     //! method for envelope ionization
     virtual void envelopeIonization( Particles *, unsigned int, unsigned int, std::vector<double> *, std::vector<double> *, std::vector<double> *, std::vector<double> *, Patch *, Projector *, int = 0, int = 0 ){};
 

--- a/src/Ionization/Ionization.h
+++ b/src/Ionization/Ionization.h
@@ -18,7 +18,7 @@ public:
     virtual ~Ionization() {};
 
     //! Overloading of () operator
-    virtual void operator()(Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *) {};
+    virtual void operator()(Particles *, unsigned int, unsigned int, const std::vector<const std::vector<double> *>&, Patch *, Projector *) {};
 
     Particles new_electrons;
     

--- a/src/Ionization/IonizationFactory.h
+++ b/src/Ionization/IonizationFactory.h
@@ -7,6 +7,8 @@
 #include "Params.h"
 #include "Species.h"
 #include "IonizationTunnel.h"
+#include "IonizationTunnelTL.h"
+#include "IonizationTunnelKAG.h"
 #include "Tools.h"
 
 //! this class create and associate the right ionization model to species
@@ -23,11 +25,11 @@ class IonizationFactory
             checkMaxCharge(species);
             checkNotLaserEnvelopeModel(params);
             if (bsi_model == "none") {
-                Ionize = new IonizationTunnel<0>( params, species ); // The original model included in Smilei
+                Ionize = new IonizationTunnel( params, species ); // The original model included in Smilei
             } else if (bsi_model == "Tong_Lin") {
-                Ionize = new IonizationTunnel<1>( params, species ); // Tong&Lin
+                Ionize = new IonizationTunnelTL( params, species ); // Tong&Lin
             } else if (bsi_model == "KAG") {
-                Ionize = new IonizationTunnel<2>( params, species ); // KAG
+                Ionize = new IonizationTunnelKAG( params, species ); // KAG
             }
             
         } else if( model == "tunnel_envelope_averaged" ) {

--- a/src/Ionization/IonizationFromRate.cpp
+++ b/src/Ionization/IonizationFromRate.cpp
@@ -24,7 +24,7 @@ IonizationFromRate::IonizationFromRate( Params &params, Species *species ) : Ion
 
 
 
-void IonizationFromRate::operator()( Particles *particles, unsigned int ipart_min, unsigned int ipart_max, vector<double> *, Patch *patch, Projector *, int )
+void IonizationFromRate::operator()( Particles *particles, unsigned int ipart_min, unsigned int ipart_max, vector<vector<double> *>, Patch *patch, Projector *, int )
 {
 
     //unsigned int Z, Zp1, newZ, k_times;

--- a/src/Ionization/IonizationFromRate.cpp
+++ b/src/Ionization/IonizationFromRate.cpp
@@ -24,7 +24,7 @@ IonizationFromRate::IonizationFromRate( Params &params, Species *species ) : Ion
 
 
 
-void IonizationFromRate::operator()( Particles *particles, unsigned int ipart_min, unsigned int ipart_max, vector<vector<double> *>, Patch *patch, Projector *, int )
+void IonizationFromRate::operator()( Particles *particles, unsigned int ipart_min, unsigned int ipart_max, vector<vector<double> *>, Patch *patch, Projector *)
 {
 
     //unsigned int Z, Zp1, newZ, k_times;

--- a/src/Ionization/IonizationFromRate.cpp
+++ b/src/Ionization/IonizationFromRate.cpp
@@ -24,7 +24,7 @@ IonizationFromRate::IonizationFromRate( Params &params, Species *species ) : Ion
 
 
 
-void IonizationFromRate::operator()( Particles *particles, unsigned int ipart_min, unsigned int ipart_max, vector<vector<double> *>, Patch *patch, Projector *)
+void IonizationFromRate::operator()( Particles *particles, unsigned int ipart_min, unsigned int ipart_max, const vector<const vector<double> *>&, Patch *patch, Projector *)
 {
 
     //unsigned int Z, Zp1, newZ, k_times;

--- a/src/Ionization/IonizationFromRate.h
+++ b/src/Ionization/IonizationFromRate.h
@@ -19,7 +19,7 @@ public:
     IonizationFromRate( Params &params, Species *species );
 
     //! apply the FromRate Ionization model to the species
-    void operator()( Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *, int ipart_ref = 0 ) override;
+    void operator()( Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *) override;
 
 private:
 

--- a/src/Ionization/IonizationFromRate.h
+++ b/src/Ionization/IonizationFromRate.h
@@ -19,7 +19,7 @@ public:
     IonizationFromRate( Params &params, Species *species );
 
     //! apply the FromRate Ionization model to the species
-    void operator()( Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *) override;
+    void operator()( Particles *, unsigned int, unsigned int, const std::vector<const std::vector<double> *>&, Patch *, Projector *) override;
 
 private:
 

--- a/src/Ionization/IonizationFromRate.h
+++ b/src/Ionization/IonizationFromRate.h
@@ -19,7 +19,7 @@ public:
     IonizationFromRate( Params &params, Species *species );
 
     //! apply the FromRate Ionization model to the species
-    void operator()( Particles *, unsigned int, unsigned int, std::vector<double> *, Patch *, Projector *, int ipart_ref = 0 ) override;
+    void operator()( Particles *, unsigned int, unsigned int, std::vector<std::vector<double> *>, Patch *, Projector *, int ipart_ref = 0 ) override;
 
 private:
 

--- a/src/Ionization/IonizationTunnel.cpp
+++ b/src/Ionization/IonizationTunnel.cpp
@@ -14,7 +14,6 @@ IonizationTunnel::IonizationTunnel(Params &params, Species *species) : Ionizatio
                                 // the Hartree coefficients; C_nl is set 
                                 // to 1 for a neutral atom
     double Blm           = 1.;
-    double ionization_tl_parameter;
     std::string tunneling_model = species->ionization_model_;
 
     // Ionization potential & quantum numbers (all in atomic units 1 au = 27.2116 eV)
@@ -47,11 +46,9 @@ IonizationTunnel::IonizationTunnel(Params &params, Species *species) : Ionizatio
         if(tunneling_model == "tunnel") {
             Anl = pow( 2, cst+1.0 ) / \
                 ( cst*tgamma( cst ) );
-        } else {
-            if( Z>0 ) {
-                Anl = pow( 2, cst+1.0 ) / \
+        } else if ( Z>0 ) {
+            Anl = pow( 2, cst+1.0 ) / \
                                 ( cst*tgamma( cst/2.0+Azimuthal_quantum_number[Z]+1 )*tgamma( cst/2.0-Azimuthal_quantum_number[Z]) );
-            }
         }
 
         alpha_tunnel[Z] = cst - 1.0 - abs_m;

--- a/src/Ionization/IonizationTunnel.cpp
+++ b/src/Ionization/IonizationTunnel.cpp
@@ -60,7 +60,7 @@ IonizationTunnel::IonizationTunnel(Params &params, Species *species) : Ionizatio
 }
 
 void IonizationTunnel::operator()(Particles *particles, unsigned int ipart_min, unsigned int ipart_max,
-                                                vector<vector<double>*> Epart, Patch *patch, Projector *Proj)
+                                                const vector<const vector<double>*>& Epart, Patch *patch, Projector *Proj)
 {
     unsigned int Z, Zp1, newZ, k_times;
     double ran_p, Mult, D_sum, P_sum, Pint_tunnel;
@@ -145,7 +145,7 @@ void IonizationTunnel::operator()(Particles *particles, unsigned int ipart_min, 
     }  // Loop on particles
 }
 
-ElectricFields IonizationTunnel::calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart)
+ElectricFields IonizationTunnel::calculateElectricFields(const vector<const vector<double>*>& Epart, unsigned int ipart)
 {
     ElectricFields E;
     int nparts = Epart[0]->size() / 3;

--- a/src/Ionization/IonizationTunnel.cpp
+++ b/src/Ionization/IonizationTunnel.cpp
@@ -84,6 +84,7 @@ void IonizationTunnel::operator()(Particles *particles, unsigned int ipart_min, 
         if (E.abs < 1e-10) {
             continue;
         }
+        E.inv = 1/E.abs;
 
         // --------------------------------
         // Start of the Monte-Carlo routine
@@ -155,7 +156,6 @@ ElectricFields IonizationTunnel::calculateElectricFields(vector<vector<double>*>
     E.y = (*Epart[0])[nparts+ipart];
     E.z = (*Epart[0])[2*nparts+ipart];
     E.abs = EC_to_au * sqrt(E.x*E.x + E.y*E.y + E.z*E.z);
-    E.inv = 1/E.abs;
     return E;
 }
 

--- a/src/Ionization/IonizationTunnel.cpp
+++ b/src/Ionization/IonizationTunnel.cpp
@@ -179,7 +179,7 @@ void IonizationTunnel::computeIonizationCurrents(unsigned int ipart, unsigned in
     }
 }
 
-void IonizationTunnel::createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields&, const SimulationContext& context)
+void IonizationTunnel::createNewElectrons(unsigned int ipart, unsigned int, unsigned int k_times, const ElectricFields&, const SimulationContext& context)
 {
     if (k_times != 0) {
         new_electrons.createParticle();

--- a/src/Ionization/IonizationTunnel.cpp
+++ b/src/Ionization/IonizationTunnel.cpp
@@ -1,0 +1,211 @@
+#include "IonizationTunnel.h"
+#include "IonizationTables.h"
+#include "Tools.h"
+
+IonizationTunnel::IonizationTunnel(Params &params, Species *species) : Ionization(params, species)
+{
+    DEBUG("Creating the Tunnel Ionizaton class");
+    double abs_m         = 0;
+    double g_factor      = 1;
+    double Anl           = 4.;  // the initial value is set to 4 on purpose, 
+                                // as A_nl = 4*C_nl^2, where C_nl are 
+                                // the Hartree coefficients; C_nl is set 
+                                // to 1 for a neutral atom
+    double Blm           = 1.;
+    double ionization_tl_parameter;
+    std::string tunneling_model = species->ionization_model_;
+
+    // Ionization potential & quantum numbers (all in atomic units 1 au = 27.2116 eV)
+    atomic_number_ = species->atomic_number_;
+    Potential.resize(atomic_number_);
+    Azimuthal_quantum_number.resize(atomic_number_);
+
+    alpha_tunnel.resize(atomic_number_);
+    beta_tunnel.resize(atomic_number_);
+    gamma_tunnel.resize(atomic_number_);
+
+    for (unsigned int Z = 0; Z < atomic_number_; Z++) {
+        DEBUG("Z : " << Z);
+
+        if (tunneling_model == "tunnel_full_PPT") {
+            abs_m = abs(IonizationTables::magnetic_atomic_number(atomic_number_, Z));
+            g_factor = IonizationTables::magnetic_degeneracy_atomic_number(atomic_number_, Z);
+        } 
+
+        Potential[Z] = IonizationTables::ionization_energy(atomic_number_, Z) * eV_to_au;
+        Azimuthal_quantum_number[Z] = IonizationTables::azimuthal_atomic_number(atomic_number_, Z);
+
+        DEBUG("Potential: " << Potential[Z] << " Az.q.num: " << Azimuthal_quantum_number[Z]);
+
+        Blm      = ( 2.*Azimuthal_quantum_number[Z]+1.0 ) * \
+                   tgamma(Azimuthal_quantum_number[Z]+abs_m+1) / \
+                   ( pow( 2, abs_m )*tgamma(abs_m+1)*tgamma(Azimuthal_quantum_number[Z]-abs_m+1) );
+
+        double cst = ((double)Z + 1.0) * sqrt(2.0 / Potential[Z]);
+        if(tunneling_model == "tunnel") {
+            Anl = pow( 2, cst+1.0 ) / \
+                ( cst*tgamma( cst ) );
+        } else {
+            if( Z>0 ) {
+                Anl = pow( 2, cst+1.0 ) / \
+                                ( cst*tgamma( cst/2.0+Azimuthal_quantum_number[Z]+1 )*tgamma( cst/2.0-Azimuthal_quantum_number[Z]) );
+            }
+        }
+
+        alpha_tunnel[Z] = cst - 1.0 - abs_m;
+        beta_tunnel[Z] = g_factor*Anl*Blm * Potential[Z] * au_to_w0;
+        gamma_tunnel[Z] = 2.0 * sqrt(2.0 * Potential[Z] * 2.0 * Potential[Z] * 2.0 * Potential[Z]);
+    }
+
+    DEBUG("Finished Creating the Tunnel Ionizaton class");
+}
+
+void IonizationTunnel::operator()(Particles *particles, unsigned int ipart_min, unsigned int ipart_max,
+                                                vector<vector<double>*> Epart, Patch *patch, Projector *Proj)
+{
+    unsigned int Z, Zp1, newZ, k_times;
+    double ran_p, Mult, D_sum, P_sum, Pint_tunnel;
+    vector<double> IonizRate_tunnel(atomic_number_), Dnom_tunnel(atomic_number_);
+    ElectricFields E;
+
+    for (unsigned int ipart = ipart_min; ipart < ipart_max; ipart++) {
+        // Current charge state of the ion
+        Z = (unsigned int)(particles->charge(ipart));
+
+        // If ion already fully ionized then skip
+        if (Z == atomic_number_) {
+            continue;
+        }
+
+        // Absolute value of the electric field normalized in atomic units
+        E = calculateElectricFields(Epart, ipart);
+        if (E.abs < 1e-10) {
+            continue;
+        }
+
+        // --------------------------------
+        // Start of the Monte-Carlo routine
+        // --------------------------------
+
+        ran_p = patch->rand_->uniform();
+        IonizRate_tunnel[Z] = ionizationRate(Z, E);
+
+        // k_times will give the nb of ionization events
+        k_times = 0;
+        Zp1 = Z + 1;
+
+        if (Zp1 == atomic_number_) {
+            // if ionization of the last electron: single ionization
+            // -----------------------------------------------------
+            if (ran_p < 1.0 - exp(-IonizRate_tunnel[Z] * dt)) {
+                k_times = 1;
+            }
+
+        } else {
+            // else : multiple ionization can occur in one time-step
+            //        partial & final ionization are decoupled (see Nuter Phys.
+            //        Plasmas)
+            // -------------------------------------------------------------------------
+
+            // initialization
+            Mult = 1.0;
+            Dnom_tunnel[0] = 1.0;
+            Pint_tunnel = exp(-IonizRate_tunnel[Z] * dt);  // cummulative prob.
+
+            // multiple ionization loop while Pint_tunnel < ran_p and still partial
+            // ionization
+            while ((Pint_tunnel < ran_p) and (k_times < atomic_number_ - Zp1)) {
+                newZ = Zp1 + k_times;
+                IonizRate_tunnel[newZ] = ionizationRate(newZ, E);
+                D_sum = 0.0;
+                P_sum = 0.0;
+                Mult *= IonizRate_tunnel[Z + k_times];
+                for (unsigned int i = 0; i < k_times + 1; i++) {
+                    Dnom_tunnel[i] = Dnom_tunnel[i] / (IonizRate_tunnel[newZ] - IonizRate_tunnel[Z + i]);
+                    D_sum += Dnom_tunnel[i];
+                    P_sum += exp(-IonizRate_tunnel[Z + i] * dt) * Dnom_tunnel[i];
+                }
+                Dnom_tunnel[k_times + 1] = -D_sum;
+                P_sum = P_sum + Dnom_tunnel[k_times + 1] * exp(-IonizRate_tunnel[newZ] * dt);
+                Pint_tunnel = Pint_tunnel + P_sum * Mult;
+
+                k_times++;
+            }  // END while
+
+            // final ionization (of last electron)
+            if (((1.0 - Pint_tunnel) > ran_p) && (k_times == atomic_number_ - Zp1)) {
+                k_times++;
+            }
+        }  // END Multiple ionization routine
+
+        computeIonizationCurrents(ipart, Z, k_times, E, patch, Proj, particles);
+        createNewElectrons(ipart, k_times, Z, particles, patch, E);
+
+    }  // Loop on particles
+}
+
+ElectricFields IonizationTunnel::calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart)
+{
+    ElectricFields E;
+    int nparts = Epart[0]->size() / 3;
+
+    E.x = (*Epart[0])[ipart];
+    E.y = (*Epart[0])[nparts+ipart];
+    E.z = (*Epart[0])[2*nparts+ipart];
+    E.abs = EC_to_au * sqrt(E.x*E.x + E.y*E.y + E.z*E.z);
+    E.inv = 1/E.abs;
+    return E;
+}
+
+void IonizationTunnel::computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles* particles) 
+{
+    if (patch->EMfields->Jx_ != NULL) {  // For the moment ionization current is
+                                         // not accounted for in AM geometry
+        double TotalIonizPot = 0.0;
+        for (unsigned int i=0; i<k_times; i++) {
+            TotalIonizPot += Potential[Z+i];
+        }
+
+        double factorJion_0 = au_to_mec2 * EC_to_au * EC_to_au * invdt;
+        double factorJion = factorJion_0 * E.inv * E.inv;
+        factorJion *= TotalIonizPot;
+
+        LocalFields Jion;
+        Jion.x = factorJion * E.x;
+        Jion.y = factorJion * E.y;
+        Jion.z = factorJion * E.z;
+
+        Proj->ionizationCurrents(patch->EMfields->Jx_, patch->EMfields->Jy_, patch->EMfields->Jz_, *particles, ipart, Jion);
+    }
+}
+
+void IonizationTunnel::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, ElectricFields)
+{
+    if (k_times != 0) {
+        new_electrons.createParticle();
+        int idNew = new_electrons.size() - 1;
+        for (unsigned int i = 0; i < new_electrons.dimension(); i++) {
+            new_electrons.position(i, idNew) = particles->position(i, ipart);
+        }
+        for (unsigned int i = 0; i < 3; i++) {
+            new_electrons.momentum(i, idNew) = particles->momentum(i, ipart) * ionized_species_invmass;
+        }
+        new_electrons.weight(idNew) = double(k_times) * particles->weight(ipart);
+        new_electrons.charge(idNew) = -1;
+
+        if (save_ion_charge_) {
+            ion_charge_.push_back(particles->charge(ipart));
+        }
+
+        // Increase the charge of the particle
+        particles->charge(ipart) += k_times;
+    }
+}
+
+
+double IonizationTunnel::ionizationRate(const int Z, ElectricFields E)
+{
+    double delta = gamma_tunnel[Z] / E.abs;
+    return beta_tunnel[Z] * exp(-delta * one_third + alpha_tunnel[Z] * log(delta));
+}
+

--- a/src/Ionization/IonizationTunnel.cpp
+++ b/src/Ionization/IonizationTunnel.cpp
@@ -159,7 +159,7 @@ ElectricFields IonizationTunnel::calculateElectricFields(vector<vector<double>*>
     return E;
 }
 
-void IonizationTunnel::computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles* particles) 
+void IonizationTunnel::computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, Patch *patch, Projector *Proj, Particles* particles) 
 {
     if (patch->EMfields->Jx_ != NULL) {  // For the moment ionization current is
                                          // not accounted for in AM geometry
@@ -181,7 +181,7 @@ void IonizationTunnel::computeIonizationCurrents(unsigned int ipart, int Z, unsi
     }
 }
 
-void IonizationTunnel::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, ElectricFields)
+void IonizationTunnel::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, const ElectricFields&)
 {
     if (k_times != 0) {
         new_electrons.createParticle();
@@ -205,7 +205,7 @@ void IonizationTunnel::createNewElectrons(unsigned int ipart, unsigned int k_tim
 }
 
 
-double IonizationTunnel::ionizationRate(const int Z, ElectricFields E)
+double IonizationTunnel::ionizationRate(unsigned int Z, const ElectricFields& E)
 {
     double delta = gamma_tunnel[Z] / E.abs;
     return beta_tunnel[Z] * exp(-delta * one_third + alpha_tunnel[Z] * log(delta));

--- a/src/Ionization/IonizationTunnel.cpp
+++ b/src/Ionization/IonizationTunnel.cpp
@@ -1,6 +1,8 @@
 #include "IonizationTunnel.h"
 #include "IonizationTables.h"
 #include "Tools.h"
+#include "Particles.h"
+#include "Species.h"
 
 IonizationTunnel::IonizationTunnel(Params &params, Species *species) : Ionization(params, species)
 {

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -22,7 +22,7 @@ class IonizationTunnel : public Ionization
    public:
     IonizationTunnel(Params &params, Species *species);
 
-    void operator()(Particles *, unsigned int, unsigned int, vector<vector<double>*>, Patch *, Projector *) override;
+    void operator()(Particles *, unsigned int, unsigned int, const vector<const vector<double>*>&, Patch *, Projector *) override;
 
    protected:
     struct SimulationContext {
@@ -33,7 +33,7 @@ class IonizationTunnel : public Ionization
 
     virtual void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context);;
     virtual void createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields&, const SimulationContext& context);
-    virtual ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
+    virtual ElectricFields calculateElectricFields(const vector<const vector<double>*>& Epart, unsigned int ipart);
     virtual double ionizationRate(unsigned int Z, const ElectricFields& E);
 
     static constexpr double one_third_ = 1. / 3.;

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -25,8 +25,14 @@ class IonizationTunnel : public Ionization
     void operator()(Particles *, unsigned int, unsigned int, vector<vector<double>*>, Patch *, Projector *) override;
 
    protected:
-    virtual void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, Patch *patch, Projector *Proj, Particles *particles);
-    virtual void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, const ElectricFields&);
+    struct SimulationContext {
+        Particles *particles;
+        Patch *patch;
+        Projector *Proj;
+    };
+
+    virtual void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context);;
+    virtual void createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields&, const SimulationContext& context);
     virtual ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
     virtual double ionizationRate(unsigned int Z, const ElectricFields& E);
 

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -36,10 +36,10 @@ class IonizationTunnel : public Ionization
     virtual ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
     virtual double ionizationRate(unsigned int Z, const ElectricFields& E);
 
-    static constexpr double one_third = 1. / 3.;
+    static constexpr double one_third_ = 1. / 3.;
     unsigned int atomic_number_;
-    std::vector<double> Potential, Azimuthal_quantum_number;
-    std::vector<double> alpha_tunnel, beta_tunnel, gamma_tunnel;
+    std::vector<double> potential_, azimuthal_quantum_number_;
+    std::vector<double> alpha_tunnel_, beta_tunnel_, gamma_tunnel_;
 };
 
 #endif

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -5,8 +5,9 @@
 #include <vector>
 
 #include "Ionization.h"
-#include "Particles.h"
-#include "Species.h"
+
+class Particles;
+class Species;
 
 struct ElectricFields {
     double x;

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -128,7 +128,6 @@ inline void IonizationTunnel<Model>::operator()(Particles *particles, unsigned i
     double TotalIonizPot, E, invE, factorJion, ran_p, Mult, D_sum, P_sum, Pint_tunnel;
     vector<double> IonizRate_tunnel(atomic_number_), Dnom_tunnel(atomic_number_);
     LocalFields Jion;
-    double factorJion_0 = au_to_mec2 * EC_to_au * EC_to_au * invdt;
 
     int nparts = Epart->size() / 3;
     double *Ex = &((*Epart)[0 * nparts]);
@@ -157,7 +156,6 @@ inline void IonizationTunnel<Model>::operator()(Particles *particles, unsigned i
         // --------------------------------
 
         invE = 1. / E;
-        factorJion = factorJion_0 * invE * invE;
         ran_p = patch->rand_->uniform();
         IonizRate_tunnel[Z] = ionizationRate(Z, E);
 
@@ -218,6 +216,16 @@ inline void IonizationTunnel<Model>::operator()(Particles *particles, unsigned i
         // Compute ionization current
         if (patch->EMfields->Jx_ != NULL) {  // For the moment ionization current is
                                              // not accounted for in AM geometry
+            double TotalIonizPotNew = 0.0;
+            for (unsigned int i=0; i<k_times; i++) {
+                TotalIonizPotNew += Potential[Z+i];
+            }
+            if (TotalIonizPotNew != TotalIonizPot) {
+                ERROR( "TotalIonizPotNew not equal to TotalIonizPot. This is super sad and making me depressed :( ." );
+            }
+
+            double factorJion_0 = au_to_mec2 * EC_to_au * EC_to_au * invdt;
+            factorJion = factorJion_0 * invE * invE;
             factorJion *= TotalIonizPot;
             Jion.x = factorJion * *(Ex + ipart);
             Jion.y = factorJion * *(Ey + ipart);

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -43,7 +43,7 @@ class IonizationTunnel : public Ionization
 
    protected:
     virtual inline void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles);
-    virtual inline void createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles, Patch *, ElectricFields);
+    virtual inline void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, ElectricFields);
     virtual inline ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
     virtual inline double ionizationRate(const int Z, ElectricFields E);
 
@@ -214,7 +214,7 @@ inline void IonizationTunnel<Model>::operator()(Particles *particles, unsigned i
         }  // END Multiple ionization routine
 
         computeIonizationCurrents(ipart, Z, k_times, E, patch, Proj, particles);
-        createNewElectrons(ipart, k_times, particles);
+        createNewElectrons(ipart, k_times, Z, particles, patch, E);
 
     }  // Loop on particles
 }
@@ -257,7 +257,7 @@ inline void IonizationTunnel<Model>::computeIonizationCurrents(unsigned int ipar
 }
 
 template<int Model>
-inline void IonizationTunnel<Model>::createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles, Patch *, ElectricFields)
+inline void IonizationTunnel<Model>::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, ElectricFields)
 {
     if (k_times != 0) {
         new_electrons.createParticle();

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -2,14 +2,11 @@
 #define IONIZATIONTUNNEL_H
 
 #include <cmath>
-#include <functional>
 #include <vector>
 
 #include "Ionization.h"
-#include "IonizationTables.h"
 #include "Particles.h"
 #include "Species.h"
-#include "Tools.h"
 
 struct ElectricFields {
     double x;
@@ -19,302 +16,23 @@ struct ElectricFields {
     double abs;
 };
 
-
-
-class Particles;
-
-// std::string species->tunneling_model_ : choice of the tunneling model 
-//                       "tunnel" - for the ADK (l* = n*-1) model with the magnetic quantum number m set to 0 for all electrons
-//                       "tunnel_full_PPT" - for the PPT model, in which A_nl is given by the Hartree formula and m can be non-zero for p-, d-, ... states
-//
-// int Model             : the choice of the barrier suppression ionization model
-//                       0 for no barrier suppression (the tunneling formula is used)
-//                       1 - Tong-Lin exponential suppression formula
-//                       2 - Kostyukov-Artemenko-Golovanov model
-//                       All BSI models can be combined with different tunneling formulas switched by Tunneling_Model
-
-template <int Model>
 class IonizationTunnel : public Ionization
 {
    public:
-    inline IonizationTunnel(Params &params, Species *species);
+    IonizationTunnel(Params &params, Species *species);
 
     void operator()(Particles *, unsigned int, unsigned int, vector<vector<double>*>, Patch *, Projector *) override;
 
    protected:
-    virtual inline void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles);
-    virtual inline void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, ElectricFields);
-    virtual inline ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
-    virtual inline double ionizationRate(const int Z, ElectricFields E);
-
-   private:
+    virtual void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles);
+    virtual void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, ElectricFields);
+    virtual ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
+    virtual double ionizationRate(const int Z, ElectricFields E);
 
     static constexpr double one_third = 1. / 3.;
     unsigned int atomic_number_;
     std::vector<double> Potential, Azimuthal_quantum_number;
     std::vector<double> alpha_tunnel, beta_tunnel, gamma_tunnel;
-
-    // Tong&Lin
-    std::vector<double> lambda_tunnel;
 };
-
-template <int Model>
-IonizationTunnel<Model>::IonizationTunnel(Params &params, Species *species) : Ionization(params, species)
-{
-    DEBUG("Creating the Tunnel Ionizaton class");
-    double abs_m         = 0;
-    double g_factor      = 1;
-    double Anl           = 4.;  // the initial value is set to 4 on purpose, 
-                                // as A_nl = 4*C_nl^2, where C_nl are 
-                                // the Hartree coefficients; C_nl is set 
-                                // to 1 for a neutral atom
-    double Blm           = 1.;
-    double ionization_tl_parameter;
-    std::string tunneling_model = species->ionization_model_;
-
-    // Ionization potential & quantum numbers (all in atomic units 1 au = 27.2116 eV)
-    atomic_number_ = species->atomic_number_;
-    Potential.resize(atomic_number_);
-    Azimuthal_quantum_number.resize(atomic_number_);
-
-    alpha_tunnel.resize(atomic_number_);
-    beta_tunnel.resize(atomic_number_);
-    gamma_tunnel.resize(atomic_number_);
-
-    // TODO: C++17: Change into if constexpr
-    if (Model == 1) {
-        ionization_tl_parameter = species->ionization_tl_parameter_;  // species->ionization_tl_parameter_ is
-                                                                       // double Varies from 6 to 9. This is
-                                                                       // the alpha parameter in Tong-Lin
-                                                                       // exponential, see Eq. (6) in [M F
-                                                                       // Ciappina and S V Popruzhenko 2020
-                                                                       // Laser Phys. Lett. 17 025301 2020].
-        lambda_tunnel.resize(atomic_number_);
-    }
-
-    for (unsigned int Z = 0; Z < atomic_number_; Z++) {
-        DEBUG("Z : " << Z);
-
-        if (tunneling_model == "tunnel_full_PPT") {
-            abs_m = abs(IonizationTables::magnetic_atomic_number(atomic_number_, Z));
-            g_factor = IonizationTables::magnetic_degeneracy_atomic_number(atomic_number_, Z);
-        } 
-
-        Potential[Z] = IonizationTables::ionization_energy(atomic_number_, Z) * eV_to_au;
-        Azimuthal_quantum_number[Z] = IonizationTables::azimuthal_atomic_number(atomic_number_, Z);
-
-        DEBUG("Potential: " << Potential[Z] << " Az.q.num: " << Azimuthal_quantum_number[Z]);
-
-        Blm      = ( 2.*Azimuthal_quantum_number[Z]+1.0 ) * \
-                   tgamma(Azimuthal_quantum_number[Z]+abs_m+1) / \
-                   ( pow( 2, abs_m )*tgamma(abs_m+1)*tgamma(Azimuthal_quantum_number[Z]-abs_m+1) );
-
-        double cst = ((double)Z + 1.0) * sqrt(2.0 / Potential[Z]);
-        if(tunneling_model == "tunnel") {
-            Anl = pow( 2, cst+1.0 ) / \
-                ( cst*tgamma( cst ) );
-        } else {
-            if( Z>0 ) {
-                Anl = pow( 2, cst+1.0 ) / \
-                                ( cst*tgamma( cst/2.0+Azimuthal_quantum_number[Z]+1 )*tgamma( cst/2.0-Azimuthal_quantum_number[Z]) );
-            }
-        }
-
-        alpha_tunnel[Z] = cst - 1.0 - abs_m;
-        beta_tunnel[Z] = g_factor*Anl*Blm * Potential[Z] * au_to_w0;
-        gamma_tunnel[Z] = 2.0 * sqrt(2.0 * Potential[Z] * 2.0 * Potential[Z] * 2.0 * Potential[Z]);
-        // TODO: C++17: Change into if constexpr
-        if (Model == 1) {
-            lambda_tunnel[Z] = ionization_tl_parameter * cst * cst / gamma_tunnel[Z];
-        }
-    }
-
-    DEBUG("Finished Creating the Tunnel Ionizaton class");
-
-
-}
-
-template <int Model>
-inline void IonizationTunnel<Model>::operator()(Particles *particles, unsigned int ipart_min, unsigned int ipart_max,
-                                                vector<vector<double>*> Epart, Patch *patch, Projector *Proj)
-{
-    unsigned int Z, Zp1, newZ, k_times;
-    double ran_p, Mult, D_sum, P_sum, Pint_tunnel;
-    vector<double> IonizRate_tunnel(atomic_number_), Dnom_tunnel(atomic_number_);
-    ElectricFields E;
-
-    for (unsigned int ipart = ipart_min; ipart < ipart_max; ipart++) {
-        // Current charge state of the ion
-        Z = (unsigned int)(particles->charge(ipart));
-
-        // If ion already fully ionized then skip
-        if (Z == atomic_number_) {
-            continue;
-        }
-
-        // Absolute value of the electric field normalized in atomic units
-        E = calculateElectricFields(Epart, ipart);
-        if (E.abs < 1e-10) {
-            continue;
-        }
-
-        // --------------------------------
-        // Start of the Monte-Carlo routine
-        // --------------------------------
-
-        ran_p = patch->rand_->uniform();
-        IonizRate_tunnel[Z] = ionizationRate(Z, E);
-
-        // k_times will give the nb of ionization events
-        k_times = 0;
-        Zp1 = Z + 1;
-
-        if (Zp1 == atomic_number_) {
-            // if ionization of the last electron: single ionization
-            // -----------------------------------------------------
-            if (ran_p < 1.0 - exp(-IonizRate_tunnel[Z] * dt)) {
-                k_times = 1;
-            }
-
-        } else {
-            // else : multiple ionization can occur in one time-step
-            //        partial & final ionization are decoupled (see Nuter Phys.
-            //        Plasmas)
-            // -------------------------------------------------------------------------
-
-            // initialization
-            Mult = 1.0;
-            Dnom_tunnel[0] = 1.0;
-            Pint_tunnel = exp(-IonizRate_tunnel[Z] * dt);  // cummulative prob.
-
-            // multiple ionization loop while Pint_tunnel < ran_p and still partial
-            // ionization
-            while ((Pint_tunnel < ran_p) and (k_times < atomic_number_ - Zp1)) {
-                newZ = Zp1 + k_times;
-                IonizRate_tunnel[newZ] = ionizationRate(newZ, E);
-                D_sum = 0.0;
-                P_sum = 0.0;
-                Mult *= IonizRate_tunnel[Z + k_times];
-                for (unsigned int i = 0; i < k_times + 1; i++) {
-                    Dnom_tunnel[i] = Dnom_tunnel[i] / (IonizRate_tunnel[newZ] - IonizRate_tunnel[Z + i]);
-                    D_sum += Dnom_tunnel[i];
-                    P_sum += exp(-IonizRate_tunnel[Z + i] * dt) * Dnom_tunnel[i];
-                }
-                Dnom_tunnel[k_times + 1] = -D_sum;
-                P_sum = P_sum + Dnom_tunnel[k_times + 1] * exp(-IonizRate_tunnel[newZ] * dt);
-                Pint_tunnel = Pint_tunnel + P_sum * Mult;
-
-                k_times++;
-            }  // END while
-
-            // final ionization (of last electron)
-            if (((1.0 - Pint_tunnel) > ran_p) && (k_times == atomic_number_ - Zp1)) {
-                k_times++;
-            }
-        }  // END Multiple ionization routine
-
-        computeIonizationCurrents(ipart, Z, k_times, E, patch, Proj, particles);
-        createNewElectrons(ipart, k_times, Z, particles, patch, E);
-
-    }  // Loop on particles
-}
-
-template<int Model>
-inline ElectricFields IonizationTunnel<Model>::calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart)
-{
-    ElectricFields E;
-    int nparts = Epart[0]->size() / 3;
-
-    E.x = (*Epart[0])[ipart];
-    E.y = (*Epart[0])[nparts+ipart];
-    E.z = (*Epart[0])[2*nparts+ipart];
-    E.abs = EC_to_au * sqrt(E.x*E.x + E.y*E.y + E.z*E.z);
-    E.inv = 1/E.abs;
-    return E;
-}
-
-template<int Model>
-inline void IonizationTunnel<Model>::computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles* particles) 
-{
-    if (patch->EMfields->Jx_ != NULL) {  // For the moment ionization current is
-                                         // not accounted for in AM geometry
-        double TotalIonizPot = 0.0;
-        for (unsigned int i=0; i<k_times; i++) {
-            TotalIonizPot += Potential[Z+i];
-        }
-
-        double factorJion_0 = au_to_mec2 * EC_to_au * EC_to_au * invdt;
-        double factorJion = factorJion_0 * E.inv * E.inv;
-        factorJion *= TotalIonizPot;
-
-        LocalFields Jion;
-        Jion.x = factorJion * E.x;
-        Jion.y = factorJion * E.y;
-        Jion.z = factorJion * E.z;
-
-        Proj->ionizationCurrents(patch->EMfields->Jx_, patch->EMfields->Jy_, patch->EMfields->Jz_, *particles, ipart, Jion);
-    }
-}
-
-template<int Model>
-inline void IonizationTunnel<Model>::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, ElectricFields)
-{
-    if (k_times != 0) {
-        new_electrons.createParticle();
-        int idNew = new_electrons.size() - 1;
-        for (unsigned int i = 0; i < new_electrons.dimension(); i++) {
-            new_electrons.position(i, idNew) = particles->position(i, ipart);
-        }
-        for (unsigned int i = 0; i < 3; i++) {
-            new_electrons.momentum(i, idNew) = particles->momentum(i, ipart) * ionized_species_invmass;
-        }
-        new_electrons.weight(idNew) = double(k_times) * particles->weight(ipart);
-        new_electrons.charge(idNew) = -1;
-
-        if (save_ion_charge_) {
-            ion_charge_.push_back(particles->charge(ipart));
-        }
-
-        // Increase the charge of the particle
-        particles->charge(ipart) += k_times;
-    }
-}
-
-
-template <int Model>
-inline double IonizationTunnel<Model>::ionizationRate(const int Z, ElectricFields E)
-{
-    double delta = gamma_tunnel[Z] / E.abs;
-    return beta_tunnel[Z] * exp(-delta * one_third + alpha_tunnel[Z] * log(delta));
-}
-
-// Tong&Ling: 1
-template <>
-inline double IonizationTunnel<1>::ionizationRate(const int Z, ElectricFields E)
-{
-    const double delta = gamma_tunnel[Z] / E.abs;
-    return beta_tunnel[Z] * exp(-delta * one_third + alpha_tunnel[Z] * log(delta) - E.abs * lambda_tunnel[Z]);
-}
-
-// BSI: 2
-template <>
-inline double IonizationTunnel<2>::ionizationRate(const int Z, ElectricFields E)
-{
-    constexpr double IH = 13.598434005136;
-    double ratio_of_IPs = IH / IonizationTables::ionization_energy(atomic_number_, Z);
-
-    double BSI_rate_quadratic = 2.4 * (E.abs * E.abs) * ratio_of_IPs * ratio_of_IPs * au_to_w0;
-    double BSI_rate_linear = 0.8 * E.abs * sqrt(ratio_of_IPs) * au_to_w0;
-    double delta = gamma_tunnel[Z] / E.abs;
-    double Tunnel_rate = beta_tunnel[Z] * exp(-delta / 3.0 + alpha_tunnel[Z] * log(delta));
-
-    if (BSI_rate_quadratic >= BSI_rate_linear) {
-        return BSI_rate_linear;
-    } else if (Tunnel_rate >= BSI_rate_quadratic) {
-        return BSI_rate_quadratic;
-    } else {
-        return Tunnel_rate;
-    }
-}
 
 #endif

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -39,16 +39,15 @@ class IonizationTunnel : public Ionization
    public:
     inline IonizationTunnel(Params &params, Species *species);
 
-    inline void operator()(Particles *, unsigned int, unsigned int, vector<vector<double>*>, Patch *, Projector *,
-                           int ipart_ref = 0) override;
+    void operator()(Particles *, unsigned int, unsigned int, vector<vector<double>*>, Patch *, Projector *) override;
 
    protected:
-    inline void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles);
-    inline void createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles);
-    inline ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
+    virtual inline void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles);
+    virtual inline void createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles, Patch *, ElectricFields);
+    virtual inline ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
+    virtual inline double ionizationRate(const int Z, ElectricFields E);
 
    private:
-    inline double ionizationRate(const int Z, ElectricFields E);
 
     static constexpr double one_third = 1. / 3.;
     unsigned int atomic_number_;
@@ -137,7 +136,7 @@ IonizationTunnel<Model>::IonizationTunnel(Params &params, Species *species) : Io
 
 template <int Model>
 inline void IonizationTunnel<Model>::operator()(Particles *particles, unsigned int ipart_min, unsigned int ipart_max,
-                                                vector<vector<double>*> Epart, Patch *patch, Projector *Proj, int ipart_ref)
+                                                vector<vector<double>*> Epart, Patch *patch, Projector *Proj)
 {
     unsigned int Z, Zp1, newZ, k_times;
     double ran_p, Mult, D_sum, P_sum, Pint_tunnel;
@@ -258,7 +257,7 @@ inline void IonizationTunnel<Model>::computeIonizationCurrents(unsigned int ipar
 }
 
 template<int Model>
-inline void IonizationTunnel<Model>::createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles)
+inline void IonizationTunnel<Model>::createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles, Patch *, ElectricFields)
 {
     if (k_times != 0) {
         new_electrons.createParticle();

--- a/src/Ionization/IonizationTunnel.h
+++ b/src/Ionization/IonizationTunnel.h
@@ -25,10 +25,10 @@ class IonizationTunnel : public Ionization
     void operator()(Particles *, unsigned int, unsigned int, vector<vector<double>*>, Patch *, Projector *) override;
 
    protected:
-    virtual void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles);
-    virtual void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, ElectricFields);
+    virtual void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, Patch *patch, Projector *Proj, Particles *particles);
+    virtual void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *, const ElectricFields&);
     virtual ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart);
-    virtual double ionizationRate(const int Z, ElectricFields E);
+    virtual double ionizationRate(unsigned int Z, const ElectricFields& E);
 
     static constexpr double one_third = 1. / 3.;
     unsigned int atomic_number_;

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -29,7 +29,7 @@ IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &para
 }
 
 
-inline ElectricFields IonizationTunnelEnvelopeAveraged::calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) {
+ElectricFields IonizationTunnelEnvelopeAveraged::calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) {
     EnvelopeElectricFields E;
     int nparts = Epart[0]->size() / 3;
 
@@ -55,7 +55,7 @@ inline ElectricFields IonizationTunnelEnvelopeAveraged::calculateElectricFields(
     return E;
 }
 
-inline double IonizationTunnelEnvelopeAveraged::ionizationRate(const int Z, ElectricFields E)
+double IonizationTunnelEnvelopeAveraged::ionizationRate(const int Z, ElectricFields E)
 {
     double coeff_ellipticity_in_ionization_rate;
 
@@ -73,12 +73,12 @@ inline double IonizationTunnelEnvelopeAveraged::ionizationRate(const int Z, Elec
     return coeff_ellipticity_in_ionization_rate * ionizRate;
 }
 
-inline void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles* particles) 
+void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles* particles) 
 {
     // ---- Ionization ion current cannot be computed with the envelope ionization model
 }
 
-inline void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, EnvelopeElectricFields E)
+void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, EnvelopeElectricFields E)
 {
     double Aabs, p_perp; 
     if( k_times !=0 ) {

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -60,7 +60,6 @@ double IonizationTunnelEnvelopeAveraged::ionizationRate(unsigned int Z, const El
     double coeff_ellipticity_in_ionization_rate;
 
     double delta = gamma_tunnel[Z] / E.abs;
-    double ionizRate = beta_tunnel[Z] * exp( -delta*one_third + alpha_tunnel[Z]*log( delta ) );
 
     // Corrections on averaged ionization rate given by the polarization ellipticity  
     if( ellipticity==0. ){ // linear polarization
@@ -68,12 +67,14 @@ double IonizationTunnelEnvelopeAveraged::ionizationRate(unsigned int Z, const El
     } else if( ellipticity==1. ){ // circular polarization
         // for circular polarization, the ionization rate is unchanged
         coeff_ellipticity_in_ionization_rate = 1.; 
+    } else {
+        ERROR("ellipticity not in {0,1}")
     }
 
-    return coeff_ellipticity_in_ionization_rate * ionizRate;
+    return coeff_ellipticity_in_ionization_rate * IonizationTunnel::ionizationRate(Z, E);
 }
 
-void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context) 
+void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int, unsigned int, unsigned int, const ElectricFields&, const SimulationContext&) 
 {
     // ---- Ionization ion current cannot be computed with the envelope ionization model
 }

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -1,5 +1,4 @@
 #include "IonizationTunnelEnvelopeAveraged.h"
-#include "IonizationTables.h"
 
 #include <cmath>
 
@@ -9,7 +8,7 @@
 using namespace std;
 
 
-IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &params, Species *species ) : IonizationTunnel<0>( params, species )
+IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &params, Species *species ) : IonizationTunnel( params, species )
 {
     DEBUG( "Creating the Tunnel Envelope Ionizaton Averaged class" );
 

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -8,39 +8,21 @@
 
 using namespace std;
 
+struct EnvelopeElectricFields : ElectricFields {
+    double env;
+    double x_env;
+    double Phi_env;
+};
 
 
-IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &params, Species *species ) : Ionization( params, species )
+IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &params, Species *species ) : IonizationTunnel<0>( params, species )
 {
     DEBUG( "Creating the Tunnel Envelope Ionizaton Averaged class" );
-    
-    atomic_number_          = species->atomic_number_;
-    
-    // Ionization potential & quantum numbers (all in atomic units 1 au = 27.2116 eV)
-    Potential.resize( atomic_number_ );
-    Azimuthal_quantum_number.resize( atomic_number_ );
-    for( int Zstar=0; Zstar<( int )atomic_number_; Zstar++ ) {
-        Potential               [Zstar] = IonizationTables::ionization_energy( atomic_number_, Zstar ) * eV_to_au;
-        Azimuthal_quantum_number[Zstar] = IonizationTables::azimuthal_atomic_number( atomic_number_, Zstar );
-    }
-    
-    for( unsigned int i=0; i<atomic_number_; i++ ) {
-        DEBUG( "ioniz: i " << i << " potential: " << Potential[i] << " Az.q.num: " << Azimuthal_quantum_number[i] );
-    }
-    
-    one_third = 1.0/3.0;
-    
-    alpha_tunnel.resize( atomic_number_+1 );
-    beta_tunnel.resize( atomic_number_+1 );
-    gamma_tunnel.resize( atomic_number_+1 );
+
     Ip_times2_to_minus3ov4.resize( atomic_number_+1 );
     
     for( unsigned int Z=0 ; Z<atomic_number_ ; Z++ ) {
         DEBUG( "Z : " << Z );
-        double cst      = ( ( double )Z+1.0 ) * sqrt( 2.0/Potential[Z] );
-        alpha_tunnel[Z] = cst-1.0; // 2(n^*)-1
-        beta_tunnel[Z]  = pow( 2, alpha_tunnel[Z] ) * ( 8.*Azimuthal_quantum_number[Z]+4.0 ) / ( cst*tgamma( cst ) ) * Potential[Z] * au_to_w0;
-        gamma_tunnel[Z] = 2.0 * sqrt( 2.0*Potential[Z] * 2.0*Potential[Z] * 2.0*Potential[Z] );   // 2*(2I_p)^{3/2}
         Ip_times2_to_minus3ov4[Z] = 1.0 / sqrt(sqrt((2.*Potential[Z] * 2.*Potential[Z] * 2.*Potential[Z]))); // (2I_p)^{-3/4}
     }
     
@@ -53,210 +35,127 @@ IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &para
     
 }
 
-void IonizationTunnelEnvelopeAveraged::envelopeIonization( Particles *particles, unsigned int ipart_min, unsigned int ipart_max, std::vector<double> *Epart, std::vector<double> *EnvEabs_part, std::vector<double> *EnvExabs_part, std::vector<double> *Phipart, Patch *patch, Projector *, int ibin, int ipart_ref )
-{
-    unsigned int Z, Zp1, newZ, k_times;
-    double E, E_sq, EnvE_sq, Aabs, invE, delta, ran_p, Mult, D_sum, P_sum, Pint_tunnel;
-    double coeff_ellipticity_in_ionization_rate = 1.;
-    double p_perp; 
-    vector<double> IonizRate_tunnel_envelope( atomic_number_ ), Dnom_tunnel( atomic_number_ );
-    
-    
-    int nparts = Epart->size()/3;
-    double *Ex      = &( ( *Epart )[0*nparts] );
-    double *Ey      = &( ( *Epart )[1*nparts] );
-    double *Ez      = &( ( *Epart )[2*nparts] );
-    double *E_env   = &( ( *EnvEabs_part )[0*nparts] );
-    double *Ex_env  = &( ( *EnvExabs_part )[0*nparts] );
-    double *Phi_env = &( ( *Phipart )[0*nparts] );
-    
-    for( unsigned int ipart=ipart_min ; ipart<ipart_max; ipart++ ) {
-    
-        // Current charge state of the ion
-        Z = ( unsigned int )( particles->charge( ipart ) );
-    
-        // If ion already fully ionized then skip
-        if( Z==atomic_number_ ) {
-            continue;
-        }
-    
-    
-        // Absolute value of the electric field |E_plasma| (from the plasma) normalized in atomic units
-        E_sq    = (EC_to_au * EC_to_au) * ( ( *( Ex+ipart-ipart_ref ) ) * ( *( Ex+ipart-ipart_ref ) )
-                                    + ( *( Ey+ipart-ipart_ref ) ) * ( *( Ey+ipart-ipart_ref ) )
-                                    + ( *( Ez+ipart-ipart_ref ) ) * ( *( Ez+ipart-ipart_ref ) ) );
-        // Laser envelope electric field normalized in atomic units, using both transverse and longitudinal components:
-        // |E_envelope|^2 = |Env_E|^2 + |Env_Ex|^2
 
-        EnvE_sq = (EC_to_au * EC_to_au) * ( *( E_env+ipart-ipart_ref )) * ( *( E_env+ipart-ipart_ref ) ) + (EC_to_au * EC_to_au) * 
-                   ( *( Ex_env+ipart-ipart_ref ) ) * ( *( Ex_env+ipart-ipart_ref ) );
+inline ElectricFields IonizationTunnelEnvelopeAveraged::calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) {
+    EnvelopeElectricFields E;
+    int nparts = Epart[0]->size() / 3;
 
-        // Effective electric field for ionization:
-        // |E| = sqrt(|E_plasma|^2+|E_envelope|^2)
-        E = sqrt(E_sq+EnvE_sq);
-    
-        if( E<1e-10 ) {
-            continue;
-        }
-    
-        // --------------------------------
-        // Start of the Monte-Carlo routine
-        // --------------------------------
-    
-        invE = 1./E;
-        delta      = gamma_tunnel[Z]*invE; // 2*(2I_p)^{3/2}/E
-        ran_p = patch->rand_->uniform();
-        IonizRate_tunnel_envelope[Z] = beta_tunnel[Z] * exp( -delta*one_third + alpha_tunnel[Z]*log( delta ) );
-    
-        // Corrections on averaged ionization rate given by the polarization ellipticity  
-        if( ellipticity==0. ){ // linear polarization
-            coeff_ellipticity_in_ionization_rate = sqrt((3./M_PI)/delta*2.);
-        } else if( ellipticity==1. ){ // circular polarization
-            coeff_ellipticity_in_ionization_rate = 1.; // for circular polarization, the ionization rate is unchanged
-        }
+    E.x = (*Epart[0])[ipart];
+    E.y = (*Epart[0])[nparts+ipart];
+    E.z = (*Epart[0])[2*nparts+ipart];
+    E.env = (*Epart[1])[ipart];
+    E.x_env = (*Epart[2])[ipart];
+    E.Phi_env = (*Epart[3])[ipart];
 
-        IonizRate_tunnel_envelope[Z] = coeff_ellipticity_in_ionization_rate * IonizRate_tunnel_envelope[Z];
-    
-        // k_times will give the nb of ionization events
-        k_times = 0;
-        Zp1=Z+1;
+    // Absolute value of the electric field |E_plasma| (from the plasma) normalized in atomic units
+    double E_sq    = (EC_to_au * EC_to_au) * ( E.x*E.x + E.y*E.y + E.z*E.z );
 
-        if( Zp1 == atomic_number_ ) {
-            // if ionization of the last electron: single ionization
-            // -----------------------------------------------------
-            if( ran_p < 1.0 -exp( -IonizRate_tunnel_envelope[Z]*dt ) ) {
-                k_times        = 1;
-                //Ip_times2_power_minus3ov4 = Ip_times2_to_minus3ov4[Z];
-            }
-    
-        } else {
-            // else : multiple ionization can occur in one time-step
-            //        partial & final ionization are decoupled (see Nuter Phys. Plasmas)
-            // -------------------------------------------------------------------------
-    
-            // initialization
-            Mult = 1.0;
-            Dnom_tunnel[0]=1.0;
-            Pint_tunnel = exp( -IonizRate_tunnel_envelope[Z]*dt ); // cummulative prob.
-    
-            //multiple ionization loop while Pint_tunnel < ran_p and still partial ionization
-            while( ( Pint_tunnel < ran_p ) and ( k_times < atomic_number_-Zp1 ) ) {
-                newZ = Zp1+k_times;
-                delta = gamma_tunnel[newZ]*invE;
+    // Laser envelope electric field normalized in atomic units, using both transverse and longitudinal components:
+    // |E_envelope|^2 = |Env_E|^2 + |Env_Ex|^2
+    double EnvE_sq = (EC_to_au * EC_to_au) * ( E.env*E.env + E.x_env*E.x_env );
 
-                // Corrections on averaged ionization rate given by the polarization ellipticity  
-                if( ellipticity==0. ){ // linear polarization
-                    //coeff_ellipticity_in_ionization_rate = sqrt((3./M_PI)/(gamma_tunnel[newZ-1]*invE)*2.);
-                    coeff_ellipticity_in_ionization_rate = sqrt((3./M_PI)/delta*2.);
-                } else if( ellipticity==1. ){ // circular polarization
-                    coeff_ellipticity_in_ionization_rate = 1.; // for circular polarization, the ionization rate is unchanged
-                }
-
-                IonizRate_tunnel_envelope[newZ] = coeff_ellipticity_in_ionization_rate * beta_tunnel[newZ]
-                                                  * exp( -delta*one_third+alpha_tunnel[newZ]*log( delta ) );
-
-                D_sum = 0.0;
-                P_sum = 0.0;
-                Mult  *= IonizRate_tunnel_envelope[Z+k_times];
-                for( unsigned int i=0; i<k_times+1; i++ ) {
-                    Dnom_tunnel[i]=Dnom_tunnel[i]/( IonizRate_tunnel_envelope[newZ]-IonizRate_tunnel_envelope[Z+i] );
-                    D_sum += Dnom_tunnel[i];
-                    P_sum += exp( -IonizRate_tunnel_envelope[Z+i]*dt )*Dnom_tunnel[i];
-                }
-                Dnom_tunnel[k_times+1] -= D_sum;
-                P_sum                   = P_sum + Dnom_tunnel[k_times+1]*exp( -IonizRate_tunnel_envelope[newZ]*dt );
-                Pint_tunnel             = Pint_tunnel + P_sum*Mult;
-    
-                k_times++;
-           
-                //Ip_times2_power_minus3ov4 += Ip_times2_to_minus3ov4[newZ-1];
-            }//END while
-    
-            // final ionization (of last electron)
-            if( ( ( 1.0-Pint_tunnel )>ran_p ) && ( k_times==atomic_number_-Zp1 ) ) {
-                k_times++;
-                //Ip_times2_power_minus3ov4 += Ip_times2_to_minus3ov4[atomic_number_-1];
-            }
-        }//END Multiple ionization routine
-    
-        // ---- Ionization ion current cannot be computed with the envelope ionization model
-      
-        // ---- Creation of the new electrons
-        
-        if( k_times !=0 ) {
-            // loop on all the ionization levels that have been ionized for this ion:
-            // each level creates an electron
-            for( unsigned int ionized_level = 0; ionized_level < k_times ; ionized_level++){
-                SMILEI_UNUSED( ibin );
-                
-                new_electrons.createParticle();
-                //new_electrons.initialize( new_electrons.size()+1, new_electrons.dimension() );
-                int idNew = new_electrons.size() - 1;
-
-                // The new electron is in the same position of the atom where it originated from
-                for( unsigned int i=0; i<new_electrons.dimension(); i++ ) {
-                    new_electrons.position( i, idNew )=particles->position( i, ipart );
-                }
-                for( unsigned int i=0; i<3; i++ ) {
-                    new_electrons.momentum( i, idNew ) = particles->momentum( i, ipart )*ionized_species_invmass;
-                }
-
-           
-                // ----  Initialise the momentum, weight and charge of the new electron
-
-                if (ellipticity==0.){ // linear polarization
-
-                    double rand_gaussian  = patch->rand_->normal();
-
-                    Aabs    = sqrt(2. * (*(Phi_env+ipart-ipart_ref))  ); // envelope of the laser vector potential component along the polarization direction
-                
-                    // recreate gaussian distribution with rms momentum spread for linear polarization, estimated by C.B. Schroeder
-                    // C. B. Schroeder et al., Phys. Rev. ST Accel. Beams 17, 2014, first part of Eqs. 7,10
-                    double Ip_times2_power_minus3ov4 = Ip_times2_to_minus3ov4[Z+ionized_level];
-                    p_perp = rand_gaussian * Aabs * sqrt(1.5*E) * Ip_times2_power_minus3ov4;
-
-                    // add the transverse momentum p_perp to obtain a gaussian distribution
-                    // in the momentum in the polarization direction p_perp, following Schroeder's result
-                    new_electrons.momentum( 1, idNew ) += p_perp*cos_phi;
-                    new_electrons.momentum( 2, idNew ) += p_perp*sin_phi;
-
-                    // initialize px to take into account the average drift <px>=A^2/4 and the px=|p_perp|^2/2 relation
-                    // Note: the agreement in the phase space between envelope and standard laser simulation will be seen only after the passage of the ionizing laser
-                    new_electrons.momentum( 0, idNew ) += Aabs*Aabs/4. + p_perp*p_perp/2.;
-
-                } else if (ellipticity==1.){ // circular polarization
-
-                    // extract a random angle between 0 and 2pi, and assign p_perp = eA
-                    double rand_times_2pi = patch->rand_->uniform_2pi(); // from uniform distribution between [0,2pi]
-                
-                    Aabs    = sqrt(2. * (*(Phi_env+ipart-ipart_ref))  );
-
-                    p_perp = Aabs;   // in circular polarization it corresponds to a0/sqrt(2)
-                    new_electrons.momentum( 1, idNew ) += p_perp*cos(rand_times_2pi)/sqrt(2);
-                    new_electrons.momentum( 2, idNew ) += p_perp*sin(rand_times_2pi)/sqrt(2);
-     
-                    // initialize px to take into account the average drift <px>=A^2/4 and the px=|p_perp|^2/2 result
-                    // Note: the agreement in the phase space between envelope and standard laser simulation will be seen only after the passage of the ionizing laser
-                    new_electrons.momentum( 0, idNew ) += Aabs*Aabs/2.;
-            
-                }
-
-                if( save_ion_charge_ ) {
-                    ion_charge_.push_back( particles->charge( ipart ) );
-                }
-                
-                // weight and charge of the new electron
-                new_electrons.weight( idNew )= particles->weight( ipart );
-                new_electrons.charge( idNew )= -1;
-
-            } // end loop on electrons to create
-
-            // Increase the charge of the ion particle
-            particles->charge( ipart ) += k_times;
-        } // end if electrons are created
-    
-    
-    } // Loop on particles
-
+    // Effective electric field for ionization:
+    // |E| = sqrt(|E_plasma|^2+|E_envelope|^2)
+    E.abs = sqrt(E_sq+EnvE_sq);
+    E.inv = 1/E.abs;
+ 
+    return E;
 }
 
+inline double IonizationTunnelEnvelopeAveraged::ionizationRate(const int Z, ElectricFields E)
+{
+    double coeff_ellipticity_in_ionization_rate;
+
+    double delta = gamma_tunnel[Z] / E.abs;
+    double ionizRate = beta_tunnel[Z] * exp( -delta*one_third + alpha_tunnel[Z]*log( delta ) );
+
+    // Corrections on averaged ionization rate given by the polarization ellipticity  
+    if( ellipticity==0. ){ // linear polarization
+        coeff_ellipticity_in_ionization_rate = sqrt((3./M_PI)/delta*2.);
+    } else if( ellipticity==1. ){ // circular polarization
+        // for circular polarization, the ionization rate is unchanged
+        coeff_ellipticity_in_ionization_rate = 1.; 
+    }
+
+    return coeff_ellipticity_in_ionization_rate * ionizRate;
+}
+
+inline void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles* particles) 
+{
+    // ---- Ionization ion current cannot be computed with the envelope ionization model
+}
+
+inline void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles, Patch *patch, EnvelopeElectricFields E)
+{
+    double Aabs, p_perp; 
+    if( k_times !=0 ) {
+        // loop on all the ionization levels that have been ionized for this ion:
+        // each level creates an electron
+        for( unsigned int ionized_level = 0; ionized_level < k_times ; ionized_level++){
+            
+            new_electrons.createParticle();
+            //new_electrons.initialize( new_electrons.size()+1, new_electrons.dimension() );
+            int idNew = new_electrons.size() - 1;
+
+            // The new electron is in the same position of the atom where it originated from
+            for( unsigned int i=0; i<new_electrons.dimension(); i++ ) {
+                new_electrons.position( i, idNew )=particles->position( i, ipart );
+            }
+            for( unsigned int i=0; i<3; i++ ) {
+                new_electrons.momentum( i, idNew ) = particles->momentum( i, ipart )*ionized_species_invmass;
+            }
+
+       
+            // ----  Initialise the momentum, weight and charge of the new electron
+
+            if (ellipticity==0.){ // linear polarization
+
+                double rand_gaussian  = patch->rand_->normal();
+
+                Aabs    = sqrt(2. * E.Phi_env ); // envelope of the laser vector potential component along the polarization direction
+            
+                // recreate gaussian distribution with rms momentum spread for linear polarization, estimated by C.B. Schroeder
+                // C. B. Schroeder et al., Phys. Rev. ST Accel. Beams 17, 2014, first part of Eqs. 7,10
+                double Ip_times2_power_minus3ov4 = Ip_times2_to_minus3ov4[Z+ionized_level];
+                p_perp = rand_gaussian * Aabs * sqrt(1.5*E.abs) * Ip_times2_power_minus3ov4;
+
+                // add the transverse momentum p_perp to obtain a gaussian distribution
+                // in the momentum in the polarization direction p_perp, following Schroeder's result
+                new_electrons.momentum( 1, idNew ) += p_perp*cos_phi;
+                new_electrons.momentum( 2, idNew ) += p_perp*sin_phi;
+
+                // initialize px to take into account the average drift <px>=A^2/4 and the px=|p_perp|^2/2 relation
+                // Note: the agreement in the phase space between envelope and standard laser simulation will be seen only after the passage of the ionizing laser
+                new_electrons.momentum( 0, idNew ) += Aabs*Aabs/4. + p_perp*p_perp/2.;
+
+            } else if (ellipticity==1.){ // circular polarization
+
+                // extract a random angle between 0 and 2pi, and assign p_perp = eA
+                double rand_times_2pi = patch->rand_->uniform_2pi(); // from uniform distribution between [0,2pi]
+            
+                Aabs    = sqrt(2. * E.Phi_env+ipart );
+
+                p_perp = Aabs;   // in circular polarization it corresponds to a0/sqrt(2)
+                new_electrons.momentum( 1, idNew ) += p_perp*cos(rand_times_2pi)/sqrt(2);
+                new_electrons.momentum( 2, idNew ) += p_perp*sin(rand_times_2pi)/sqrt(2);
+ 
+                // initialize px to take into account the average drift <px>=A^2/4 and the px=|p_perp|^2/2 result
+                // Note: the agreement in the phase space between envelope and standard laser simulation will be seen only after the passage of the ionizing laser
+                new_electrons.momentum( 0, idNew ) += Aabs*Aabs/2.;
+        
+            }
+
+            if( save_ion_charge_ ) {
+                ion_charge_.push_back( particles->charge( ipart ) );
+            }
+            
+            // weight and charge of the new electron
+            new_electrons.weight( idNew )= particles->weight( ipart );
+            new_electrons.charge( idNew )= -1;
+
+        } // end loop on electrons to create
+
+        // Increase the charge of the ion particle
+        particles->charge( ipart ) += k_times;
+    } // end if electrons are created
+}

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -73,12 +73,12 @@ double IonizationTunnelEnvelopeAveraged::ionizationRate(unsigned int Z, const El
     return coeff_ellipticity_in_ionization_rate * ionizRate;
 }
 
-void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, Patch *patch, Projector *Proj, Particles* particles) 
+void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context) 
 {
     // ---- Ionization ion current cannot be computed with the envelope ionization model
 }
 
-void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, const EnvelopeElectricFields& E)
+void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const EnvelopeElectricFields& E, const SimulationContext& context)
 {
     double Aabs, p_perp; 
     if( k_times !=0 ) {
@@ -92,10 +92,10 @@ void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, un
 
             // The new electron is in the same position of the atom where it originated from
             for( unsigned int i=0; i<new_electrons.dimension(); i++ ) {
-                new_electrons.position( i, idNew )=particles->position( i, ipart );
+                new_electrons.position( i, idNew )=context.particles->position( i, ipart );
             }
             for( unsigned int i=0; i<3; i++ ) {
-                new_electrons.momentum( i, idNew ) = particles->momentum( i, ipart )*ionized_species_invmass;
+                new_electrons.momentum( i, idNew ) = context.particles->momentum( i, ipart )*ionized_species_invmass;
             }
 
        
@@ -103,7 +103,7 @@ void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, un
 
             if (ellipticity==0.){ // linear polarization
 
-                double rand_gaussian  = patch->rand_->normal();
+                double rand_gaussian  = context.patch->rand_->normal();
 
                 Aabs    = sqrt(2. * E.Phi_env ); // envelope of the laser vector potential component along the polarization direction
             
@@ -124,7 +124,7 @@ void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, un
             } else if (ellipticity==1.){ // circular polarization
 
                 // extract a random angle between 0 and 2pi, and assign p_perp = eA
-                double rand_times_2pi = patch->rand_->uniform_2pi(); // from uniform distribution between [0,2pi]
+                double rand_times_2pi = context.patch->rand_->uniform_2pi(); // from uniform distribution between [0,2pi]
             
                 Aabs    = sqrt(2. * E.Phi_env );
 
@@ -139,16 +139,16 @@ void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, un
             }
 
             if( save_ion_charge_ ) {
-                ion_charge_.push_back( particles->charge( ipart ) );
+                ion_charge_.push_back( context.particles->charge( ipart ) );
             }
             
             // weight and charge of the new electron
-            new_electrons.weight( idNew )= particles->weight( ipart );
+            new_electrons.weight( idNew )= context.particles->weight( ipart );
             new_electrons.charge( idNew )= -1;
 
         } // end loop on electrons to create
 
         // Increase the charge of the ion particle
-        particles->charge( ipart ) += k_times;
+        context.particles->charge( ipart ) += k_times;
     } // end if electrons are created
 }

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -29,7 +29,7 @@ IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &para
 }
 
 
-ElectricFields IonizationTunnelEnvelopeAveraged::calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) {
+ElectricFields IonizationTunnelEnvelopeAveraged::calculateElectricFields(const vector<const vector<double>*>& Epart, unsigned int ipart) {
     ElectricFields E;
     int nparts = Epart[0]->size() / 3;
 

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -8,12 +8,6 @@
 
 using namespace std;
 
-struct EnvelopeElectricFields : ElectricFields {
-    double env;
-    double x_env;
-    double Phi_env;
-};
-
 
 IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &params, Species *species ) : IonizationTunnel<0>( params, species )
 {
@@ -85,7 +79,7 @@ inline void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned
     // ---- Ionization ion current cannot be computed with the envelope ionization model
 }
 
-inline void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles, Patch *patch, EnvelopeElectricFields E)
+inline void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, EnvelopeElectricFields E)
 {
     double Aabs, p_perp; 
     if( k_times !=0 ) {

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -126,7 +126,7 @@ void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, un
                 // extract a random angle between 0 and 2pi, and assign p_perp = eA
                 double rand_times_2pi = patch->rand_->uniform_2pi(); // from uniform distribution between [0,2pi]
             
-                Aabs    = sqrt(2. * E.Phi_env+ipart );
+                Aabs    = sqrt(2. * E.Phi_env );
 
                 p_perp = Aabs;   // in circular polarization it corresponds to a0/sqrt(2)
                 new_electrons.momentum( 1, idNew ) += p_perp*cos(rand_times_2pi)/sqrt(2);

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -55,7 +55,7 @@ ElectricFields IonizationTunnelEnvelopeAveraged::calculateElectricFields(vector<
     return E;
 }
 
-double IonizationTunnelEnvelopeAveraged::ionizationRate(const int Z, ElectricFields E)
+double IonizationTunnelEnvelopeAveraged::ionizationRate(unsigned int Z, const ElectricFields& E)
 {
     double coeff_ellipticity_in_ionization_rate;
 
@@ -73,12 +73,12 @@ double IonizationTunnelEnvelopeAveraged::ionizationRate(const int Z, ElectricFie
     return coeff_ellipticity_in_ionization_rate * ionizRate;
 }
 
-void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles* particles) 
+void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, Patch *patch, Projector *Proj, Particles* particles) 
 {
     // ---- Ionization ion current cannot be computed with the envelope ionization model
 }
 
-void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, EnvelopeElectricFields E)
+void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, const EnvelopeElectricFields& E)
 {
     double Aabs, p_perp; 
     if( k_times !=0 ) {

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.cpp
@@ -30,22 +30,22 @@ IonizationTunnelEnvelopeAveraged::IonizationTunnelEnvelopeAveraged( Params &para
 
 
 ElectricFields IonizationTunnelEnvelopeAveraged::calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) {
-    EnvelopeElectricFields E;
+    ElectricFields E;
     int nparts = Epart[0]->size() / 3;
 
     E.x = (*Epart[0])[ipart];
     E.y = (*Epart[0])[nparts+ipart];
     E.z = (*Epart[0])[2*nparts+ipart];
-    E.env = (*Epart[1])[ipart];
-    E.x_env = (*Epart[2])[ipart];
-    E.Phi_env = (*Epart[3])[ipart];
+    double E_env = (*Epart[1])[ipart];
+    double Ex_env = (*Epart[2])[ipart];
+    Phi_env_ = (*Epart[3])[ipart];
 
     // Absolute value of the electric field |E_plasma| (from the plasma) normalized in atomic units
     double E_sq    = (EC_to_au * EC_to_au) * ( E.x*E.x + E.y*E.y + E.z*E.z );
 
     // Laser envelope electric field normalized in atomic units, using both transverse and longitudinal components:
     // |E_envelope|^2 = |Env_E|^2 + |Env_Ex|^2
-    double EnvE_sq = (EC_to_au * EC_to_au) * ( E.env*E.env + E.x_env*E.x_env );
+    double EnvE_sq = (EC_to_au * EC_to_au) * ( E_env*E_env + Ex_env*Ex_env );
 
     // Effective electric field for ionization:
     // |E| = sqrt(|E_plasma|^2+|E_envelope|^2)
@@ -78,7 +78,7 @@ void IonizationTunnelEnvelopeAveraged::computeIonizationCurrents(unsigned int ip
     // ---- Ionization ion current cannot be computed with the envelope ionization model
 }
 
-void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const EnvelopeElectricFields& E, const SimulationContext& context)
+void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context)
 {
     double Aabs, p_perp; 
     if( k_times !=0 ) {
@@ -105,7 +105,7 @@ void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, un
 
                 double rand_gaussian  = context.patch->rand_->normal();
 
-                Aabs    = sqrt(2. * E.Phi_env ); // envelope of the laser vector potential component along the polarization direction
+                Aabs    = sqrt(2. * Phi_env_ ); // envelope of the laser vector potential component along the polarization direction
             
                 // recreate gaussian distribution with rms momentum spread for linear polarization, estimated by C.B. Schroeder
                 // C. B. Schroeder et al., Phys. Rev. ST Accel. Beams 17, 2014, first part of Eqs. 7,10
@@ -126,7 +126,7 @@ void IonizationTunnelEnvelopeAveraged::createNewElectrons(unsigned int ipart, un
                 // extract a random angle between 0 and 2pi, and assign p_perp = eA
                 double rand_times_2pi = context.patch->rand_->uniform_2pi(); // from uniform distribution between [0,2pi]
             
-                Aabs    = sqrt(2. * E.Phi_env );
+                Aabs    = sqrt(2. * Phi_env_ );
 
                 p_perp = Aabs;   // in circular polarization it corresponds to a0/sqrt(2)
                 new_electrons.momentum( 1, idNew ) += p_perp*cos(rand_times_2pi)/sqrt(2);

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "IonizationTunnel.h"
-#include "Tools.h"
 
 struct EnvelopeElectricFields : ElectricFields {
     double env;
@@ -17,7 +16,7 @@ struct EnvelopeElectricFields : ElectricFields {
 class Particles;
 
 //! calculate the particle tunnel ionization
-class IonizationTunnelEnvelopeAveraged : public IonizationTunnel<0>
+class IonizationTunnelEnvelopeAveraged : public IonizationTunnel
 {
 
 public:

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -24,8 +24,8 @@ public:
     double ellipticity,cos_phi,sin_phi;
 
 protected:
-    void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, Patch *patch, Projector *Proj, Particles *particles) override;
-    void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, const EnvelopeElectricFields& E);
+    void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context) override;
+    void createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const EnvelopeElectricFields& E, const SimulationContext& context);
     ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
     double ionizationRate(unsigned int Z, const ElectricFields& E) override;
 

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -19,7 +19,7 @@ public:
     double Phi_env_;
 
 protected:
-    void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context) override;
+    void computeIonizationCurrents(unsigned int, unsigned int, unsigned int, const ElectricFields&, const SimulationContext&) override;
     void createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context) override;
     ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
     double ionizationRate(unsigned int Z, const ElectricFields& E) override;

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -5,12 +5,6 @@
 
 #include "IonizationTunnel.h"
 
-struct EnvelopeElectricFields : ElectricFields {
-    double env;
-    double x_env;
-    double Phi_env;
-};
-
 class Particles;
 
 //! calculate the particle tunnel ionization
@@ -22,10 +16,11 @@ public:
     IonizationTunnelEnvelopeAveraged( Params &params, Species *species );
 
     double ellipticity,cos_phi,sin_phi;
+    double Phi_env_;
 
 protected:
     void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context) override;
-    void createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const EnvelopeElectricFields& E, const SimulationContext& context);
+    void createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context) override;
     ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
     double ionizationRate(unsigned int Z, const ElectricFields& E) override;
 

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -24,10 +24,10 @@ public:
     double ellipticity,cos_phi,sin_phi;
 
 protected:
-    void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles) override;
-    void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, EnvelopeElectricFields E);
+    void computeIonizationCurrents(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, Patch *patch, Projector *Proj, Particles *particles) override;
+    void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, const EnvelopeElectricFields& E);
     ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
-    double ionizationRate(const int Z, ElectricFields E) override;
+    double ionizationRate(unsigned int Z, const ElectricFields& E) override;
 
 private:
     std::vector<double> Ip_times2_to_minus3ov4;

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -5,24 +5,27 @@
 
 #include <vector>
 
-#include "Ionization.h"
+#include "IonizationTunnel.h"
 #include "Tools.h"
 
 
 class Particles;
 
 //! calculate the particle tunnel ionization
-class IonizationTunnelEnvelopeAveraged : public Ionization
+class IonizationTunnelEnvelopeAveraged : public IonizationTunnel<0>
 {
 
 public:
     //! Constructor for IonizationTunnelEnvelope: with no input argument
     IonizationTunnelEnvelopeAveraged( Params &params, Species *species );
-    
-    //! method for envelope ionization
-    void envelopeIonization( Particles *, unsigned int, unsigned int, std::vector<double> *, std::vector<double> *, std::vector<double> *, std::vector<double> *, Patch *, Projector *, int ibin = 0, int ipart_ref = 0 ) override;
 
     double ellipticity,cos_phi,sin_phi;
+
+protected:
+    inline void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles) override;
+    inline void createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles, Patch *patch, ElectricFields E) override;
+    inline ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
+    inline double ionizationRate(const int Z, ElectricFields E) override;
 
 private:
     unsigned int atomic_number_;

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -8,6 +8,11 @@
 #include "IonizationTunnel.h"
 #include "Tools.h"
 
+struct EnvelopeElectricFields : ElectricFields {
+    double env;
+    double x_env;
+    double Phi_env;
+};
 
 class Particles;
 
@@ -23,7 +28,7 @@ public:
 
 protected:
     inline void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles) override;
-    inline void createNewElectrons(unsigned int ipart, unsigned int k_times, Particles *particles, Patch *patch, ElectricFields E) override;
+    inline void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, EnvelopeElectricFields E);
     inline ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
     inline double ionizationRate(const int Z, ElectricFields E) override;
 
@@ -35,6 +40,5 @@ private:
     double one_third;
     std::vector<double> alpha_tunnel, beta_tunnel, gamma_tunnel,Ip_times2_to_minus3ov4;
 };
-
 
 #endif

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -1,7 +1,6 @@
 #ifndef IONIZATIONTUNNELENVELOPEAVERAGED_H
 #define IONIZATIONTUNNELENVELOPEAVERAGED_H
 
-#include <cmath>
 #include <vector>
 
 #include "IonizationTunnel.h"
@@ -25,18 +24,13 @@ public:
     double ellipticity,cos_phi,sin_phi;
 
 protected:
-    inline void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles) override;
-    inline void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, EnvelopeElectricFields E);
-    inline ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
-    inline double ionizationRate(const int Z, ElectricFields E) override;
+    void computeIonizationCurrents(unsigned int ipart, int Z, unsigned int k_times, ElectricFields E, Patch *patch, Projector *Proj, Particles *particles) override;
+    void createNewElectrons(unsigned int ipart, unsigned int k_times, unsigned int Z, Particles *particles, Patch *patch, EnvelopeElectricFields E);
+    ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
+    double ionizationRate(const int Z, ElectricFields E) override;
 
 private:
-    unsigned int atomic_number_;
-    std::vector<double> Potential;
-    std::vector<double> Azimuthal_quantum_number;
-    
-    double one_third;
-    std::vector<double> alpha_tunnel, beta_tunnel, gamma_tunnel,Ip_times2_to_minus3ov4;
+    std::vector<double> Ip_times2_to_minus3ov4;
 };
 
 #endif

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -21,7 +21,7 @@ public:
 protected:
     void computeIonizationCurrents(unsigned int, unsigned int, unsigned int, const ElectricFields&, const SimulationContext&) override;
     void createNewElectrons(unsigned int ipart, unsigned int Z, unsigned int k_times, const ElectricFields& E, const SimulationContext& context) override;
-    ElectricFields calculateElectricFields(vector<vector<double>*> Epart, unsigned int ipart) override;
+    ElectricFields calculateElectricFields(const vector<const vector<double>*>& Epart, unsigned int ipart) override;
     double ionizationRate(unsigned int Z, const ElectricFields& E) override;
 
 private:

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -15,8 +15,8 @@ public:
     //! Constructor for IonizationTunnelEnvelope: with no input argument
     IonizationTunnelEnvelopeAveraged( Params &params, Species *species );
 
-    double ellipticity,cos_phi,sin_phi;
-    double Phi_env_;
+    double ellipticity_,cos_phi_,sin_phi_;
+    double phi_env_;
 
 protected:
     void computeIonizationCurrents(unsigned int, unsigned int, unsigned int, const ElectricFields&, const SimulationContext&) override;
@@ -25,7 +25,7 @@ protected:
     double ionizationRate(unsigned int Z, const ElectricFields& E) override;
 
 private:
-    std::vector<double> Ip_times2_to_minus3ov4;
+    std::vector<double> Ip_times2_to_minus3ov4_;
 };
 
 #endif

--- a/src/Ionization/IonizationTunnelEnvelopeAveraged.h
+++ b/src/Ionization/IonizationTunnelEnvelopeAveraged.h
@@ -2,7 +2,6 @@
 #define IONIZATIONTUNNELENVELOPEAVERAGED_H
 
 #include <cmath>
-
 #include <vector>
 
 #include "IonizationTunnel.h"

--- a/src/Ionization/IonizationTunnelKAG.h
+++ b/src/Ionization/IonizationTunnelKAG.h
@@ -1,0 +1,37 @@
+#ifndef IONIZATIONTUNNELKAG_H
+#define IONIZATIONTUNNELKAG_H
+
+#include <cmath>
+
+#include "IonizationTunnel.h"
+#include "IonizationTables.h"
+#include "Particles.h"
+#include "Species.h"
+
+class Particles;
+
+class IonizationTunnelKAG : public IonizationTunnel
+{
+   public:
+    IonizationTunnelKAG(Params &params, Species *species) : IonizationTunnel(params, species) {};
+
+   protected:
+    double ionizationRate(const int Z, ElectricFields E) override {
+        constexpr double IH = 13.598434005136;
+        double ratio_of_IPs = IH / IonizationTables::ionization_energy(atomic_number_, Z);
+
+        double BSI_rate_quadratic = 2.4 * (E.abs * E.abs) * ratio_of_IPs * ratio_of_IPs * au_to_w0;
+        double BSI_rate_linear = 0.8 * E.abs * sqrt(ratio_of_IPs) * au_to_w0;
+        double Tunnel_rate = IonizationTunnel::ionizationRate(Z, E);
+
+        if (BSI_rate_quadratic >= BSI_rate_linear) {
+            return BSI_rate_linear;
+        } else if (Tunnel_rate >= BSI_rate_quadratic) {
+            return BSI_rate_quadratic;
+        } else {
+            return Tunnel_rate;
+        }
+    };
+};
+
+#endif

--- a/src/Ionization/IonizationTunnelKAG.h
+++ b/src/Ionization/IonizationTunnelKAG.h
@@ -16,7 +16,7 @@ class IonizationTunnelKAG : public IonizationTunnel
     IonizationTunnelKAG(Params &params, Species *species) : IonizationTunnel(params, species) {};
 
    protected:
-    double ionizationRate(const int Z, ElectricFields E) override {
+    double ionizationRate(unsigned int Z, const ElectricFields& E) override {
         constexpr double IH = 13.598434005136;
         double ratio_of_IPs = IH / IonizationTables::ionization_energy(atomic_number_, Z);
 

--- a/src/Ionization/IonizationTunnelTL.h
+++ b/src/Ionization/IonizationTunnelTL.h
@@ -1,0 +1,44 @@
+#ifndef IONIZATIONTUNNELTL_H
+#define IONIZATIONTUNNELTL_H
+
+#include <cmath>
+#include <vector>
+
+#include "IonizationTunnel.h"
+#include "Particles.h"
+#include "Species.h"
+#include "Tools.h"
+
+
+class Particles;
+
+class IonizationTunnelTL : public IonizationTunnel
+{
+   public:
+    IonizationTunnelTL(Params &params, Species *species) : IonizationTunnel(params, species) {
+        DEBUG("Creating the Tunnel Ionizaton class");
+        double cst;
+        // species->ionization_tl_parameter_ is double Varies from 6 to 9. This is the alpha parameter in Tong-Lin
+        // exponential, see Eq. (6) in [M F Ciappina and S V Popruzhenko 2020 Laser Phys. Lett. 17 025301 2020].
+        double ionization_tl_parameter = species->ionization_tl_parameter_;
+        lambda_tunnel.resize(atomic_number_);
+
+        for (unsigned int Z = 0; Z < atomic_number_; Z++) {
+            DEBUG("Z : " << Z);
+            cst = ((double)Z + 1.0) * sqrt(2.0 / Potential[Z]);
+            lambda_tunnel[Z] = ionization_tl_parameter * cst * cst / gamma_tunnel[Z];
+        }
+
+        DEBUG("Finished Creating the Tunnel Ionizaton class");
+    };
+  
+   protected:
+    double ionizationRate(const int Z, ElectricFields E) override {
+        return IonizationTunnel::ionizationRate(Z, E) * exp(-E.abs*lambda_tunnel[Z]);
+    };
+
+   private:
+    std::vector<double> lambda_tunnel;
+};
+
+#endif

--- a/src/Ionization/IonizationTunnelTL.h
+++ b/src/Ionization/IonizationTunnelTL.h
@@ -21,12 +21,12 @@ class IonizationTunnelTL : public IonizationTunnel
         // species->ionization_tl_parameter_ is double Varies from 6 to 9. This is the alpha parameter in Tong-Lin
         // exponential, see Eq. (6) in [M F Ciappina and S V Popruzhenko 2020 Laser Phys. Lett. 17 025301 2020].
         double ionization_tl_parameter = species->ionization_tl_parameter_;
-        lambda_tunnel.resize(atomic_number_);
+        lambda_tunnel_.resize(atomic_number_);
 
         for (unsigned int Z = 0; Z < atomic_number_; Z++) {
             DEBUG("Z : " << Z);
-            cst = ((double)Z + 1.0) * sqrt(2.0 / Potential[Z]);
-            lambda_tunnel[Z] = ionization_tl_parameter * cst * cst / gamma_tunnel[Z];
+            cst = ((double)Z + 1.0) * sqrt(2.0 / potential_[Z]);
+            lambda_tunnel_[Z] = ionization_tl_parameter * cst * cst / gamma_tunnel_[Z];
         }
 
         DEBUG("Finished Creating the Tunnel Ionizaton class");
@@ -34,11 +34,11 @@ class IonizationTunnelTL : public IonizationTunnel
   
    protected:
     double ionizationRate(unsigned int Z, const ElectricFields& E) override {
-        return IonizationTunnel::ionizationRate(Z, E) * exp(-E.abs*lambda_tunnel[Z]);
+        return IonizationTunnel::ionizationRate(Z, E) * exp(-E.abs*lambda_tunnel_[Z]);
     };
 
    private:
-    std::vector<double> lambda_tunnel;
+    std::vector<double> lambda_tunnel_;
 };
 
 #endif

--- a/src/Ionization/IonizationTunnelTL.h
+++ b/src/Ionization/IonizationTunnelTL.h
@@ -33,7 +33,7 @@ class IonizationTunnelTL : public IonizationTunnel
     };
   
    protected:
-    double ionizationRate(const int Z, ElectricFields E) override {
+    double ionizationRate(unsigned int Z, const ElectricFields& E) override {
         return IonizationTunnel::ionizationRate(Z, E) * exp(-E.abs*lambda_tunnel[Z]);
     };
 

--- a/src/Species/Species.cpp
+++ b/src/Species/Species.cpp
@@ -2075,12 +2075,13 @@ void Species::ponderomotiveUpdateSusceptibilityAndMomentum( double time_dual,
 #endif
 
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),0,5);
-                vector<double> *Epart = &( smpi->dynamics_Epart[ithread] );
+                vector<double> *Epartxyz = &( smpi->dynamics_Epart[ithread] );
                 vector<double> *EnvEabs_part = &( smpi->dynamics_EnvEabs_part[ithread] );
                 vector<double> *EnvExabs_part = &( smpi->dynamics_EnvExabs_part[ithread] );
                 vector<double> *Phipart = &( smpi->dynamics_PHIpart[ithread] );
+                vector<vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
                 Interp->envelopeFieldForIonization( EMfields, *particles, smpi, &( particles->first_index[ibin] ), &( particles->last_index[ibin] ), ithread );
-                Ionize->envelopeIonization( particles, particles->first_index[ibin], particles->last_index[ibin], Epart, EnvEabs_part, EnvExabs_part, Phipart, patch, Proj );
+                ( *Ionize )( particles, particles->first_index[ibin], particles->last_index[ibin], Epart, patch, Proj );
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),1,5);
 
 #ifdef  __DETAILED_TIMERS

--- a/src/Species/Species.cpp
+++ b/src/Species/Species.cpp
@@ -597,7 +597,7 @@ void Species::dynamics( double time_dual,
 
                 patch->startFineTimer(4);
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),0,5);
-                ( *Ionize )( particles, particles->first_index[ibin], particles->last_index[ibin], &smpi->dynamics_Epart[ithread], patch, Proj );
+                ( *Ionize )( particles, particles->first_index[ibin], particles->last_index[ibin], vector<vector<double>*>{&smpi->dynamics_Epart[ithread]}, patch, Proj );
 
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),1,5);
                 patch->stopFineTimer(4);

--- a/src/Species/Species.cpp
+++ b/src/Species/Species.cpp
@@ -597,7 +597,7 @@ void Species::dynamics( double time_dual,
 
                 patch->startFineTimer(4);
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),0,5);
-                ( *Ionize )( particles, particles->first_index[ibin], particles->last_index[ibin], vector<vector<double>*>{&smpi->dynamics_Epart[ithread]}, patch, Proj );
+                ( *Ionize )( particles, particles->first_index[ibin], particles->last_index[ibin], vector<const vector<double>*>{&smpi->dynamics_Epart[ithread]}, patch, Proj );
 
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),1,5);
                 patch->stopFineTimer(4);
@@ -2079,7 +2079,7 @@ void Species::ponderomotiveUpdateSusceptibilityAndMomentum( double time_dual,
                 vector<double> *EnvEabs_part = &( smpi->dynamics_EnvEabs_part[ithread] );
                 vector<double> *EnvExabs_part = &( smpi->dynamics_EnvExabs_part[ithread] );
                 vector<double> *Phipart = &( smpi->dynamics_PHIpart[ithread] );
-                vector<vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
+                const vector<const vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
                 Interp->envelopeFieldForIonization( EMfields, *particles, smpi, &( particles->first_index[ibin] ), &( particles->last_index[ibin] ), ithread );
                 ( *Ionize )( particles, particles->first_index[ibin], particles->last_index[ibin], Epart, patch, Proj );
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),1,5);

--- a/src/Species/SpeciesV.cpp
+++ b/src/Species/SpeciesV.cpp
@@ -1179,15 +1179,17 @@ void SpeciesV::ponderomotiveUpdateSusceptibilityAndMomentum( double time_dual,
 #ifdef  __DETAILED_TIMERS
                 timer = MPI_Wtime();
 #endif
-                vector<double> *Epart = &( smpi->dynamics_Epart[ithread] );
+                vector<double> *Epartxyz = &( smpi->dynamics_Epart[ithread] );
                 vector<double> *EnvEabs_part  = &( smpi->dynamics_EnvEabs_part[ithread] );
                 vector<double> *EnvExabs_part = &( smpi->dynamics_EnvExabs_part[ithread] );
                 vector<double> *Phipart = &( smpi->dynamics_PHIpart[ithread] );
 
+                vector<vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
+
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, ithread,0,5);
                 for( unsigned int scell = 0 ; scell < packsize_ ; scell++ ) {
                     Interp->envelopeFieldForIonization( EMfields, *particles, smpi, &( particles->first_index[ipack*packsize_+scell] ), &( particles->last_index[ipack*packsize_+scell] ), ithread );
-                    Ionize->envelopeIonization( particles, particles->first_index[ipack*packsize_+scell], particles->last_index[ipack*packsize_+scell], Epart, EnvEabs_part, EnvExabs_part, Phipart, patch, Proj );
+                    ( *Ionize )( particles, particles->first_index[ipack*packsize_+scell], particles->last_index[ipack*packsize_+scell], Epart, patch, Proj );
                 }
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, ithread,1,5);
 

--- a/src/Species/SpeciesV.cpp
+++ b/src/Species/SpeciesV.cpp
@@ -174,7 +174,7 @@ void SpeciesV::dynamics( double time_dual, unsigned int ispec,
 
         //Point to local thread dedicated buffers
         //Still needed for ionization
-        vector<double> *Epart = &( smpi->dynamics_Epart[ithread] );
+        vector<vector<double>*> Epart = {&( smpi->dynamics_Epart[ithread] ), };
 
         // Prepare particles buffers for multiphoton Breit-Wheeler
         if( Multiphoton_Breit_Wheeler_process ) {

--- a/src/Species/SpeciesV.cpp
+++ b/src/Species/SpeciesV.cpp
@@ -174,7 +174,7 @@ void SpeciesV::dynamics( double time_dual, unsigned int ispec,
 
         //Point to local thread dedicated buffers
         //Still needed for ionization
-        vector<vector<double>*> Epart = {&( smpi->dynamics_Epart[ithread] ), };
+        const vector<const vector<double>*> Epart = {&( smpi->dynamics_Epart[ithread] ), };
 
         // Prepare particles buffers for multiphoton Breit-Wheeler
         if( Multiphoton_Breit_Wheeler_process ) {
@@ -1184,7 +1184,7 @@ void SpeciesV::ponderomotiveUpdateSusceptibilityAndMomentum( double time_dual,
                 vector<double> *EnvExabs_part = &( smpi->dynamics_EnvExabs_part[ithread] );
                 vector<double> *Phipart = &( smpi->dynamics_PHIpart[ithread] );
 
-                vector<vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
+                const vector<const vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
 
                 smpi->traceEventIfDiagTracing(diag_PartEventTracing, ithread,0,5);
                 for( unsigned int scell = 0 ; scell < packsize_ ; scell++ ) {

--- a/src/Species/SpeciesVAdaptive.cpp
+++ b/src/Species/SpeciesVAdaptive.cpp
@@ -596,14 +596,15 @@ void SpeciesVAdaptive::scalarPonderomotiveUpdateSusceptibilityAndMomentum( doubl
 #ifdef  __DETAILED_TIMERS
             timer = MPI_Wtime();
 #endif
-            vector<double> *Epart = &( smpi->dynamics_Epart[ithread] );
+            vector<double> *Epartxyz = &( smpi->dynamics_Epart[ithread] );
             vector<double> *EnvEabs_part  = &( smpi->dynamics_EnvEabs_part[ithread] );
             vector<double> *EnvExabs_part = &( smpi->dynamics_EnvExabs_part[ithread] );
             vector<double> *Phipart = &( smpi->dynamics_PHIpart[ithread] );
+            vector<vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
 
             smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),0,5);
             Interp->envelopeFieldForIonization( EMfields, *particles, smpi, &( particles->first_index[0] ), &( particles->last_index[particles->last_index.size()-1] ), ithread );
-            Ionize->envelopeIonization( particles, ( particles->first_index[0] ), ( particles->last_index[particles->last_index.size()-1] ), Epart, EnvEabs_part, EnvExabs_part, Phipart, patch, Proj );
+            ( *Ionize )( particles, ( particles->first_index[0] ), ( particles->last_index[particles->last_index.size()-1] ), Epart, patch, Proj );
             smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),1,5);
 
 #ifdef  __DETAILED_TIMERS

--- a/src/Species/SpeciesVAdaptive.cpp
+++ b/src/Species/SpeciesVAdaptive.cpp
@@ -95,7 +95,7 @@ void SpeciesVAdaptive::scalarDynamics( double time_dual, unsigned int ispec,
 
         //Point to local thread dedicated buffers
         //Still needed for ionization
-        vector<vector<double>*> Epart = {&( smpi->dynamics_Epart[ithread] ), };
+        const vector<const vector<double>*> Epart = {&( smpi->dynamics_Epart[ithread] ), };
 
         //Prepare for sorting
         for( unsigned int i=0; i<count.size(); i++ ) {
@@ -600,7 +600,7 @@ void SpeciesVAdaptive::scalarPonderomotiveUpdateSusceptibilityAndMomentum( doubl
             vector<double> *EnvEabs_part  = &( smpi->dynamics_EnvEabs_part[ithread] );
             vector<double> *EnvExabs_part = &( smpi->dynamics_EnvExabs_part[ithread] );
             vector<double> *Phipart = &( smpi->dynamics_PHIpart[ithread] );
-            vector<vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
+            const vector<const vector<double>*> Epart = { Epartxyz, EnvEabs_part, EnvExabs_part, Phipart };
 
             smpi->traceEventIfDiagTracing(diag_PartEventTracing, Tools::getOMPThreadNum(),0,5);
             Interp->envelopeFieldForIonization( EMfields, *particles, smpi, &( particles->first_index[0] ), &( particles->last_index[particles->last_index.size()-1] ), ithread );

--- a/src/Species/SpeciesVAdaptive.cpp
+++ b/src/Species/SpeciesVAdaptive.cpp
@@ -95,7 +95,7 @@ void SpeciesVAdaptive::scalarDynamics( double time_dual, unsigned int ispec,
 
         //Point to local thread dedicated buffers
         //Still needed for ionization
-        vector<double> *Epart = &( smpi->dynamics_Epart[ithread] );
+        vector<vector<double>*> Epart = {&( smpi->dynamics_Epart[ithread] ), };
 
         //Prepare for sorting
         for( unsigned int i=0; i<count.size(); i++ ) {


### PR DESCRIPTION
- Make IonizationTunnelEnvelopeAveraged inherit from IonizationTunnel
- Make the KAG and TL BSI models inherit from IonizationTunnel
- Separate electron creation, ionization current computation and electric field calculation into separate methods
- Remove legacy code and unnecessary includes

TODO:
- Make tests for Envelope model more stringent for electron momentum initialisation