### PR TITLE
fix saveAs in happi.multiPlot for Scalars

### DIFF
--- a/happi/_Utils.py
+++ b/happi/_Utils.py
@@ -674,11 +674,13 @@ class _multiPlotUtil(object):
 				)
 	
 	def staticPlot(self):
+		save = SaveAs(self.saveAs, self.fig, self.dpi)
 		for Diag in self.Diags:
 			Diag._plotOnAxes(Diag._ax, Diag.getTimesteps()[-1])
 		self.legend()
 		self.plt.draw()
 		self.plt.pause(0.00001)
+		save.frame()
 	
 	def twinOptions(self, Diag):
 		if self.sameAxes:


### PR DESCRIPTION
See #842 

Special case with Scalar: the plot is not animated and thus does not go through the same function (where saveAs was handled)