### PR TITLE
ODR fix when using detailed timers

### DIFF
--- a/makefile
+++ b/makefile
@@ -197,6 +197,7 @@ endif
 # Detailed timers
 ifneq (,$(call parse_config,detailed_timers))
 	CXXFLAGS += -D__DETAILED_TIMERS
+	GPU_COMPILER_FLAGS += -D__DETAILED_TIMERS
 endif
 
 # NVIDIA GPUs


### PR DESCRIPTION
This PR addresses an ODR violation that occurs when building with detailed timers.  Currently, due to the `ifdef` guard [here](https://github.com/SmileiPIC/Smilei/blob/1e21887e68452ff1e1f71b2fa6827820f729acdc/src/Patch/Patch.h#L123-L139), host code compiled with `CXXFLAGS` vs. `GPU_COMPILER_FLAGS` gets a different layout (i.e. `sizeof(Patch)` as seen from `Patch.o` vs. `nvidiaParticles.o` differs by 56 bytes, the space needed for those guarded members).  This causes problems for a `Patch` produced in [`PatchesFactory::create`](https://github.com/SmileiPIC/Smilei/blob/1e21887e68452ff1e1f71b2fa6827820f729acdc/src/Patch/PatchesFactory.h#L20), then consumed in  [`CreateGPUParticles`](https://github.com/SmileiPIC/Smilei/blob/1e21887e68452ff1e1f71b2fa6827820f729acdc/src/Particles/nvidiaParticles.cu#L1365); in particular, these inlined [accessors](https://github.com/SmileiPIC/Smilei/blob/1e21887e68452ff1e1f71b2fa6827820f729acdc/src/Patch/Patch.h#L379-L389) will access unintended offsets, leading to garbage values. 

The proposed fix ensures that code compiled with `CXXFLAGS` vs. `GPU_COMPILER_FLAGS` both have the `__DETAILED_TIMERS` option, bringing the class layout into agreement across both TUs; this matches semantics elsewhere in the `makefile` which do propagate `define`s consistently to both `CXXFLAGS` and `GPU_COMPILER_FLAGS`.  This fix sits above `gpu_nvidia` and `gpu_amd`  and so applies to both configurations.

(On the machine where I tested, this reproduces on `develop` with a 2D GPU deck, even with a single patch.)